### PR TITLE
fix: remove copying public key

### DIFF
--- a/deploy/aws-hypervisor/scripts/init.sh
+++ b/deploy/aws-hypervisor/scripts/init.sh
@@ -10,9 +10,6 @@ instance_host="$(cat "${SCRIPT_DIR}/../${SHARED_DIR}/public_address")"
 echo "Adding host key for $instance_host to known_hosts..."
 ssh-keyscan -H "$instance_host" >> ~/.ssh/known_hosts 2>/dev/null
 
-ssh "$instance_ip 'mkdir -p ~/.ssh'"
-scp "$SSH_PUBLIC_KEY" "$instance_ip:~/.ssh/id_rsa.pub"
-
 scp "${SCRIPT_DIR}/configure.sh" "$instance_ip:~/configure.sh"
 
 # Create a minimal environment file with only the variables needed on the remote machine


### PR DESCRIPTION
upstream dev-scripts generate a public/private key pair to access the VMs by default, because we copy over the public key here it breaks that logic so we only have half of the equation in the hypervisor to ssh into the vms

removing copying over the key since its not needed and we already add the public key to the authorized keys via the cloudformation script.