### PR TITLE
Update helpers README to document multiple scripts

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,10 +1,13 @@
 # Helpers
 
-Utilities for installing RPM packages on OpenShift cluster nodes using rpm-ostree.
+Utilities for OpenShift cluster operations including package management and cluster validation.
 
 ## Description
 
-This directory contains scripts and playbooks for patching OpenShift cluster nodes with RPM packages, specifically designed for resource agent updates. The tools use rpm-ostree's override functionality to replace packages on immutable CoreOS nodes.
+This directory contains multiple helper scripts for various OpenShift cluster operations:
+
+- **Resource Agent Patching**: Scripts and playbooks for installing RPM packages on cluster nodes using rpm-ostree's override functionality
+- **Fencing Validation**: Tools for validating two-node cluster fencing configuration and health
 
 ## Requirements
 
@@ -18,9 +21,55 @@ This directory contains scripts and playbooks for patching OpenShift cluster nod
 - Inventory file containing OpenShift cluster nodes (separate from hypervisor deployment inventory, see `inventory_ocp_hosts.sample`)
 - SSH access configured for `core` user
 
-## Usage
+## Available Scripts
 
-### Shell Script
+### fencing_validator.sh
+
+Validates fencing configuration and health for two-node OpenShift clusters with STONITH-enabled Pacemaker.
+
+**Features:**
+- Non-disruptive validation (default): Checks STONITH presence/enabled status, node health, etcd quorum, and daemon status
+- Disruptive testing: Performs actual fencing of both nodes to verify recovery (optional with `--disruptive`)
+- Multiple transport methods: Auto-detection, SSH, or oc debug
+- IPv4/IPv6 support with automatic node discovery
+
+**Requirements:**
+- `oc` CLI tool (logged into OpenShift cluster) 
+- For SSH transport: passwordless sudo access to cluster nodes
+- Two-node cluster with fencing topology
+
+**Usage:**
+
+*From outside the hypervisor (uses oc debug transport by default):*
+```bash
+# Non-disruptive validation (recommended)
+./fencing_validator.sh
+
+# With custom hosts
+./fencing_validator.sh --hosts "10.0.0.10,10.0.0.11"
+```
+
+*From inside the hypervisor via ansible (requires hypervisor deployed via `make deploy`):*
+```bash
+# Copy script to hypervisor and execute remotely
+ansible all -i deploy/openshift-clusters/inventory.ini -m copy -a "src=helpers/fencing_validator.sh dest=~/fencing_validator.sh mode=0755"
+ansible all -i deploy/openshift-clusters/inventory.ini -m shell -a "./fencing_validator.sh"
+```
+
+*Disruptive testing options:*
+```bash
+# Disruptive testing (NOTE: Not yet supported - under development)
+./fencing_validator.sh --disruptive
+
+# Dry run to see what would be tested
+./fencing_validator.sh --disruptive --dry-run
+```
+
+**Note:** Disruptive testing functionality is not yet fully supported and should not be used in production environments.
+
+### resource-agents-patch.sh
+
+Patches OpenShift cluster nodes with RPM packages using rpm-ostree override functionality.
 
 ```bash
 ./resource-agents-patch.sh /path/to/package.rpm


### PR DESCRIPTION
- Document new fencing_validator.sh script alongside existing resource-agents-patch tools
- Add comprehensive usage examples including ansible deployment methods
- Clarify transport options (oc debug vs SSH) and requirements
- Note that disruptive testing is not yet supported