### PR TITLE
OCPBUGS-62233: fail gracefully on missing local python dependencies for gitconfig creation

### DIFF
--- a/deploy/openshift-clusters/roles/git-user/tasks/main.yml
+++ b/deploy/openshift-clusters/roles/git-user/tasks/main.yml
@@ -20,3 +20,4 @@
   template:
     dest: .gitconfig
     src: config.j2
+  ignore_errors: true


### PR DESCRIPTION
Install gitconfig task copies a pre-populated gitconfig. This is a leftover from inherited code and not used in TNT as of today. 

It should be reworked into a native ansible templating task later on. Since it's not currently needed, we're just letting it error out when the user's ansible-running computer doesn't have the right Python dependencies