### PR TITLE
Revert "fix: clean dirty metal3-dev-env tree between dev-scripts passes"

### DIFF
--- a/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/create.yml
+++ b/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/create.yml
@@ -13,16 +13,6 @@
     chdir: "{{dev_scripts_path}}"
     target: "requirements"
 
-# Workaround: dev-scripts' 01_install_requirements.sh uses sed -i to downgrade
-# the ansible version in metal3-dev-env/lib/common.sh, leaving the file dirty.
-# When 'make all' re-runs sync_repo_and_patch, git rebase fails on the unstaged change.
-- name: Clean dirty metal3-dev-env tree after requirements install
-  ansible.builtin.command:
-    cmd: git checkout -- lib/common.sh
-    chdir: "/opt/dev-scripts/metal3-dev-env"
-  changed_when: true
-  ignore_errors: true
-
 - name: Allow qemu read access for agent install
   ansible.posix.acl:
     path: "{{ item }}"


### PR DESCRIPTION
Reverts openshift-eng/two-node-toolbox#56
The observed dev-scripts issue can not be fixed from within TNT, it needs to be done in dev-scripts itself. Also the path for the action to be taken was harcoded, but it needed to use the WORKING_DIR variable (that can be set in the config)