### PR TITLE
fix: surface AWS CLI errors in capacity reservation query

### DIFF
--- a/deploy/aws-hypervisor/scripts/start.sh
+++ b/deploy/aws-hypervisor/scripts/start.sh
@@ -19,7 +19,7 @@ function ensure_open_capacity_preference() {
     current_pref=$(aws --region "${region}" ec2 describe-instances \
         --instance-ids "${instance_id}" \
         --query 'Reservations[0].Instances[0].CapacityReservationSpecification.CapacityReservationPreference' \
-        --output text --no-cli-pager 2>/dev/null || echo "unknown")
+        --output text --no-cli-pager || echo "query-failed")
 
     if [[ "${current_pref}" != "open" ]]; then
         msg_info "Switching capacity reservation preference to 'open'..."


### PR DESCRIPTION
## Summary
- Remove `2>/dev/null` from the capacity reservation preference query so AWS CLI errors are visible for troubleshooting
- Replace generic `"unknown"` fallback with `"query-failed"` to clearly indicate the query itself failed


🤖 Generated with [Claude Code](https://claude.com/claude-code)