### PR TITLE
OCPEDGE-2396: Add containerized resource-agents build tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ deploy/openshift-clusters/roles/install-dev/files/pull-secret.json
 deploy/openshift-clusters/vars/kcli.yml
 deploy/openshift-clusters/inventory.ini.*
 logs/*
-helpers/*.rpm
+helpers/**/*.rpm
 
 # Fetched from upstream - use helpers/etcd/fetch-podman-etcd.sh to update
 .claude/commands/etcd/pacemaker/podman-etcd.txt

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ shellcheck:
 yamlfmt:
 	@./hack/yamlfmt.sh
 
+test-resource-agents:
+	@./helpers/resource-agents-build/local-build-test.sh $(ARGS)
+
 verify:
 	VALIDATE_ONLY=true $(MAKE) shellcheck
 	VALIDATE_ONLY=true $(MAKE) yamlfmt

--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ If you're using [Claude Code](https://claude.ai/code), use the `/setup` command 
 - Validating your setup
 
 Run `/setup` to begin, or `/setup <method>` to configure a specific deployment method (aws, external, kcli, dev-scripts).
+## Helpers
+
+The [helpers/](helpers/) directory contains utilities for cluster operations including resource-agents patching, fencing validation, and containerized build validation. To quickly verify a resource-agents branch compiles on CentOS Stream 9 and 10:
+
+```bash
+make test-resource-agents                          # prompts for repo and ref
+make test-resource-agents ARGS="--ref my-branch"   # skip prompts
+```
+
+To test the built RPM on a live cluster, extract it from the Stream 9 image and patch your nodes:
+
+```bash
+# Extract the RPM from the container image
+podman create --name ra-build localhost/tnf-resource-agents-build:stream9
+podman cp ra-build:/tmp/resource-agents.rpm ./resource-agents.rpm
+podman rm ra-build
+
+# Patch cluster nodes with the extracted RPM
+ansible-playbook -i deploy/openshift-clusters/inventory.ini \
+  helpers/apply-rpm-patch.yml \
+  -l cluster_vms \
+  -e rpm_full_path=$(pwd)/resource-agents.rpm
+```
+
+Alternatively, `make patch-nodes` (from `deploy/`) clones the resource-agents repo on the EC2 hypervisor, builds the RPM there natively, and patches the cluster nodes — all in one step, without needing a local container build.
+
+See [helpers/README.md](helpers/README.md) for full documentation.
+
 ## Troubleshooting with Claude Code
 
 If you're using [Claude Code](https://claude.ai/code), it can help you troubleshoot etcd issues on two-node fencing clusters. Simply ask Claude to diagnose your etcd problems and it will automatically collect diagnostics, analyze the cluster state, and recommend remediation steps. See [.claude/commands/etcd/README.md](.claude/commands/etcd/README.md) for details.

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -253,6 +253,58 @@ If you don't want or are unable to use the previous Ansible playbooks, you can u
 
 **Note:** The shell script does not handle reboots automatically. You must manually reboot nodes after installation. Follow the instructions provided at the end of the script execution
 
+### Containerized Build Validation
+
+The `resource-agents-build/` directory contains Dockerfiles and a script for validating that resource-agents compiles correctly on CentOS Stream 9 and 10, without needing a hypervisor or cluster. This is useful for quickly verifying a branch builds before running the full `build-and-patch-resource-agents.yml` playbook.
+
+**Usage:**
+
+```bash
+cd helpers/resource-agents-build
+
+# Run both builds — prompts for repo and ref, press Enter to use defaults
+./local-build-test.sh
+
+# Skip prompts by providing values via flags
+./local-build-test.sh --repo https://github.com/myorg/resource-agents --ref my-feature-branch
+
+# Build individually with podman
+podman build -f Dockerfile.stream9 -t localhost/tnf-resource-agents-build:stream9 .
+podman build -f Dockerfile.stream10 -t localhost/tnf-resource-agents-build:stream10 .
+```
+
+**Script options:**
+
+| Option | Description |
+|--------|-------------|
+| `--repo URL` | Git repository URL (default: `https://github.com/ClusterLabs/resource-agents`) |
+| `--ref REF` | Git branch, tag, or commit (default: `main`) |
+| `-h`, `--help` | Show help |
+
+When no flags are provided, the script prompts for each value. Press Enter to use the default.
+
+**Extracting the built RPM from the container** (Stream 9 only — Stream 10 skips `make rpm`):
+
+```bash
+# Build from a specific branch
+./local-build-test.sh --ref my-feature-branch
+
+# Copy the RPM out of the Stream 9 image
+podman create --name ra-build localhost/tnf-resource-agents-build:stream9
+podman cp ra-build:/tmp/resource-agents.rpm ./resource-agents.rpm
+podman rm ra-build
+
+# Then patch your cluster nodes with it
+ansible-playbook -i ../../deploy/openshift-clusters/inventory.ini \
+  ../apply-rpm-patch.yml \
+  -l cluster_vms \
+  -e rpm_full_path=$(pwd)/resource-agents.rpm
+```
+
+This is useful when you want to validate the RPM locally before patching.
+
+**Stream 10 limitation:** `libqb-devel` is not yet available in EPEL 10. The Dockerfile builds libqb from source for `configure`/`make` validation, but skips `make rpm` since rpmbuild's `BuildRequires: libqb-devel` cannot be satisfied without the actual RPM package.
+
 ## Notes
 
 - Both tools use `rpm-ostree override replace` which is appropriate for updating existing packages

--- a/helpers/resource-agents-build/Dockerfile.stream10
+++ b/helpers/resource-agents-build/Dockerfile.stream10
@@ -1,0 +1,40 @@
+# Local test: build resource-agents RPM on CentOS Stream 10.
+# CentOS Stream 10 is the upstream for RHEL 10, which underlies RHCOS in OCP >= 4.23.
+#
+# Build with: podman build -f Dockerfile.stream10 -t localhost/tnf-resource-agents-build:stream10 .
+#
+# Customize the source repo/branch:
+#   podman build -f Dockerfile.stream10 \
+#     --build-arg RESOURCE_AGENTS_REPO=https://github.com/myorg/resource-agents \
+#     --build-arg RESOURCE_AGENTS_REF=my-feature-branch \
+#     -t localhost/tnf-resource-agents-build:stream10 .
+#
+# NOTE: libqb-devel is not yet available in EPEL 10. When it is missing, libqb is
+# built from source so that configure/make can succeed. The full `make rpm` is
+# skipped because rpmbuild's BuildRequires: libqb-devel cannot be satisfied without
+# the actual RPM package.
+FROM quay.io/centos/centos:stream10
+RUN dnf config-manager --set-enabled crb || true
+RUN dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+RUN dnf install -y git autoconf automake libtool docbook-style-xsl glib2-devel make rpm-build perl python3-devel libnet-devel python3-pyroute2 libxslt systemd which libqb check libxml2-devel
+# TODO: remove libqb source build once libqb-devel is available in EPEL/CRB for Stream 10
+# Check: podman run --rm quay.io/centos/centos:stream10 dnf repoquery libqb-devel --available
+RUN (dnf install -y libqb-devel 2>/dev/null) || ( \
+  git clone --depth 1 https://github.com/ClusterLabs/libqb /tmp/libqb-build \
+  && cd /tmp/libqb-build && autoreconf -fi && ./configure --prefix=/usr && make -j$(nproc) && make install \
+  && cd / && rm -rf /tmp/libqb-build )
+ARG RESOURCE_AGENTS_REPO=https://github.com/ClusterLabs/resource-agents
+ARG RESOURCE_AGENTS_REF=main
+RUN git clone --depth 1 "${RESOURCE_AGENTS_REPO}" /tmp/resource-agents-build \
+    && git -C /tmp/resource-agents-build fetch origin "${RESOURCE_AGENTS_REF}" \
+    && git -C /tmp/resource-agents-build checkout FETCH_HEAD
+WORKDIR /tmp/resource-agents-build
+# Stream 10: libqb-devel not in repos; we built libqb from source but rpmbuild still
+# requires the libqb-devel package. Verify configure and make (source build) only.
+RUN RPM_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "0") \
+    && autoreconf --install --force \
+    && ./configure \
+    && make VERSION="${RPM_VERSION}"
+RUN FOUND=$(find . -name 'resource-agents-*.rpm' ! -name '*debug*' ! -name '*.src.rpm' | head -1) && \
+    if [ -n "$FOUND" ]; then cp "$FOUND" /tmp/resource-agents.rpm; else echo "Stream 10: make rpm skipped (BuildRequires libqb-devel); source build OK." && touch /tmp/resource-agents.rpm; fi
+RUN test -f /tmp/resource-agents.rpm && echo "Image build complete."

--- a/helpers/resource-agents-build/Dockerfile.stream9
+++ b/helpers/resource-agents-build/Dockerfile.stream9
@@ -1,0 +1,26 @@
+# Local test: build resource-agents RPM on CentOS Stream 9.
+# CentOS Stream 9 is the upstream for RHEL 9, which underlies RHCOS in OCP <= 4.22.
+#
+# Build with: podman build -f Dockerfile.stream9 -t localhost/tnf-resource-agents-build:stream9 .
+#
+# Customize the source repo/branch:
+#   podman build -f Dockerfile.stream9 \
+#     --build-arg RESOURCE_AGENTS_REPO=https://github.com/myorg/resource-agents \
+#     --build-arg RESOURCE_AGENTS_REF=my-feature-branch \
+#     -t localhost/tnf-resource-agents-build:stream9 .
+FROM quay.io/centos/centos:stream9
+RUN dnf config-manager --set-enabled crb || true
+RUN dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf install -y git autoconf automake docbook-style-xsl glib2-devel libqb-devel make rpm-build perl python3-devel libnet-devel python3-pyroute2 libxslt systemd which
+ARG RESOURCE_AGENTS_REPO=https://github.com/ClusterLabs/resource-agents
+ARG RESOURCE_AGENTS_REF=main
+RUN git clone --depth 1 "${RESOURCE_AGENTS_REPO}" /tmp/resource-agents-build \
+    && git -C /tmp/resource-agents-build fetch origin "${RESOURCE_AGENTS_REF}" \
+    && git -C /tmp/resource-agents-build checkout FETCH_HEAD
+WORKDIR /tmp/resource-agents-build
+RUN RPM_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "0") \
+    && autoreconf --install --force \
+    && ./configure \
+    && make rpm VERSION="${RPM_VERSION}"
+RUN find . -name 'resource-agents-*.rpm' ! -name '*debug*' ! -name '*.src.rpm' | head -1 | xargs -I{} cp {} /tmp/resource-agents.rpm
+RUN test -f /tmp/resource-agents.rpm && rpm -qip /tmp/resource-agents.rpm

--- a/helpers/resource-agents-build/local-build-test.sh
+++ b/helpers/resource-agents-build/local-build-test.sh
@@ -23,15 +23,25 @@ usage() {
     echo ""
     echo "If no options are provided, the script will prompt for values."
     echo "Press Enter at each prompt to use the default."
-    exit 0
+    exit "${1:-0}"
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --repo) RESOURCE_AGENTS_REPO="$2"; shift 2 ;;
-        --ref)  RESOURCE_AGENTS_REF="$2"; shift 2 ;;
+        --repo)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: --repo requires a value (RESOURCE_AGENTS_REPO)" >&2
+                usage 1
+            fi
+            RESOURCE_AGENTS_REPO="$2"; shift 2 ;;
+        --ref)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: --ref requires a value (RESOURCE_AGENTS_REF)" >&2
+                usage 1
+            fi
+            RESOURCE_AGENTS_REF="$2"; shift 2 ;;
         -h|--help) usage ;;
-        *) echo "Unknown option: $1"; usage ;;
+        *) echo "Error: Unknown option: $1" >&2; usage 1 ;;
     esac
 done
 

--- a/helpers/resource-agents-build/local-build-test.sh
+++ b/helpers/resource-agents-build/local-build-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+# Build resource-agents RPM on CentOS Stream 9 and 10 and tag in local registry.
+# No push. Run from the helpers/resource-agents-build/ directory.
+#
+# Usage:
+#   ./local-build-test.sh                                           # prompts for repo and ref
+#   ./local-build-test.sh --repo https://github.com/myorg/resource-agents --ref my-branch
+set -euo pipefail
+
+DEFAULT_REPO="https://github.com/ClusterLabs/resource-agents"
+DEFAULT_REF="main"
+
+RESOURCE_AGENTS_REPO=""
+RESOURCE_AGENTS_REF=""
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --repo URL    Git repository URL (default: ${DEFAULT_REPO})"
+    echo "  --ref REF     Git branch, tag, or commit (default: ${DEFAULT_REF})"
+    echo "  -h, --help    Show this help"
+    echo ""
+    echo "If no options are provided, the script will prompt for values."
+    echo "Press Enter at each prompt to use the default."
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) RESOURCE_AGENTS_REPO="$2"; shift 2 ;;
+        --ref)  RESOURCE_AGENTS_REF="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# If not provided via flags, prompt the user
+if [[ -z "${RESOURCE_AGENTS_REPO}" ]]; then
+    read -rp "Resource agents repo (Enter for default: ${DEFAULT_REPO}): " input
+    RESOURCE_AGENTS_REPO="${input:-${DEFAULT_REPO}}"
+fi
+if [[ -z "${RESOURCE_AGENTS_REF}" ]]; then
+    read -rp "Resource agents ref (Enter for default: ${DEFAULT_REF}): " input
+    RESOURCE_AGENTS_REF="${input:-${DEFAULT_REF}}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+echo ""
+echo "Building with:"
+echo "  Repo: ${RESOURCE_AGENTS_REPO}"
+echo "  Ref:  ${RESOURCE_AGENTS_REF}"
+echo ""
+
+echo "Building Stream 9 image..."
+podman build -f Dockerfile.stream9 \
+    --build-arg "RESOURCE_AGENTS_REPO=${RESOURCE_AGENTS_REPO}" \
+    --build-arg "RESOURCE_AGENTS_REF=${RESOURCE_AGENTS_REF}" \
+    -t localhost/tnf-resource-agents-build:stream9 .
+
+echo "Building Stream 10 image..."
+podman build -f Dockerfile.stream10 \
+    --build-arg "RESOURCE_AGENTS_REPO=${RESOURCE_AGENTS_REPO}" \
+    --build-arg "RESOURCE_AGENTS_REF=${RESOURCE_AGENTS_REF}" \
+    -t localhost/tnf-resource-agents-build:stream10 .
+
+echo "Done. Images in local store:"
+podman images localhost/tnf-resource-agents-build --format "{{.Repository}}:{{.Tag}} {{.ID}}"


### PR DESCRIPTION
 - Add helpers/resource-agents-build/ directory with Dockerfiles (Stream 9 and 10) and scripts for building custom  resource-agents RPMs
  - `local-build-test.sh` validates that resource-agents compiles on CentOS Stream 9 and 10 locally via podman, with configurable repo/branch

Note: I've moved and edited those scripts from https://github.com/openshift/release/pull/75815 since I thought it could be more useful in this repo instead of `Release`