### PR TITLE
OCPEDGE-2489: fix: pick cluster VM IP from DHCP lease by hostname

### DIFF
--- a/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
+++ b/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Resolve VM IP from virsh net-dhcp-leases. The same MAC can appear twice (anonymous
+# DUID vs hostname); prefer the row whose Hostname matches this VM (e.g. master-0).
+# Dual-stack leases can list both ipv4 and ipv6 for one MAC; prefer ipv4, then ipv6.
+set -euo pipefail
+
+VM_NAME="${1:?VM name required}"
+
+# ostest_master_0 -> master-0; ostest_arbiter_0 -> arbiter-0; kcli e.g. *-ctlplane-0 -> ctlplane-0
+EXPECTED_HOSTNAME=""
+if [[ "$VM_NAME" =~ _(master|worker|arbiter)_([0-9]+)$ ]]; then
+  EXPECTED_HOSTNAME="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+elif [[ "$VM_NAME" =~ -(ctlplane|arbiter)-?([0-9]*)$ ]]; then
+  # Numberless kcli VMs (e.g. tnt-cluster-arbiter) have empty REMATCH[2]; DHCP host is "arbiter", not "arbiter-".
+  if [[ -n "${BASH_REMATCH[2]}" ]]; then
+    EXPECTED_HOSTNAME="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+  else
+    EXPECTED_HOSTNAME="${BASH_REMATCH[1]}"
+  fi
+fi
+
+INTERFACES=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $3 != "" && $5 != "" {print $3, tolower($5)}')
+
+lease_ip_for_mac() {
+  local LEASES="$1"
+  local MAC="$2"
+  local IP=""
+
+  if [[ -n "$EXPECTED_HOSTNAME" ]]; then
+    # awk filters by MAC (case-insensitive) so we never rely on grep exit status under set -euo pipefail.
+    # $4 is Protocol (ipv4|ipv6); prefer ipv4 when both exist (dual-stack).
+    for proto in ipv4 ipv6 ""; do
+      IP=$(echo "$LEASES" | awk -v mac="$MAC" -v host="$EXPECTED_HOSTNAME" -v proto="$proto" '
+        BEGIN { m = tolower(mac) }
+        index(tolower($0), m) == 0 { next }
+        proto != "" && $4 != proto { next }
+        $6 == host {
+          ip = $5
+          sub(/\/.*/, "", ip)
+          print ip
+          exit
+        }')
+      [[ -n "$IP" ]] && break
+    done
+  fi
+  if [[ -z "$IP" ]]; then
+    for proto in ipv4 ipv6 ""; do
+      IP=$(echo "$LEASES" | awk -v mac="$MAC" -v proto="$proto" '
+        BEGIN { m = tolower(mac) }
+        index(tolower($0), m) == 0 { next }
+        proto != "" && $4 != proto { next }
+        $6 != "-" {
+          ip = $5
+          sub(/\/.*/, "", ip)
+          print ip
+          exit
+        }')
+      [[ -n "$IP" ]] && break
+    done
+  fi
+  if [[ -z "$IP" ]]; then
+    for proto in ipv4 ipv6 ""; do
+      IP=$(echo "$LEASES" | awk -v mac="$MAC" -v proto="$proto" '
+        BEGIN { m = tolower(mac) }
+        index(tolower($0), m) == 0 { next }
+        proto != "" && $4 != proto { next }
+        {
+          ip = $5
+          sub(/\/.*/, "", ip)
+          print ip
+          exit
+        }')
+      [[ -n "$IP" ]] && break
+    done
+  fi
+  printf '%s' "$IP"
+}
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  NETWORK=$(echo "$line" | awk '{print $1}')
+  MAC=$(echo "$line" | awk '{print $2}')
+
+  LEASES=$(virsh -c qemu:///system net-dhcp-leases "$NETWORK" 2>/dev/null || true)
+  [[ -z "$LEASES" ]] && continue
+
+  IP=$(lease_ip_for_mac "$LEASES" "$MAC")
+  if [[ -n "$IP" ]]; then
+    echo "$IP"
+    exit 0
+  fi
+done <<< "$INTERFACES"
+
+exit 1

--- a/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
+++ b/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
@@ -17,36 +17,8 @@
 - name: Process cluster VMs
   when: has_cluster_vms | bool
   block:
-    - name: Get VM IP addresses from neighbor table and DHCP leases
-      shell: |
-        # Get all MAC addresses for this VM
-        MACS=$(virsh -c qemu:///system domiflist "{{ item }}" | awk 'NR>2 && $5 != "" {print tolower($5)}')
-
-        # Try to find IPs in neighbor table first (works for both IPv4 and IPv6)
-        for MAC in $MACS; do
-          # Look in neighbor table for this MAC, prefer global scope IPv6, then any IP
-          # Filter out link-local (fe80::) and ULA (fd00::) for IPv6
-          IP=$(ip neigh show | grep -i "$MAC" | awk '{print $1}' | grep -v '^fe80:' | grep -v '^fd00:' | head -n1)
-
-          if [ -n "$IP" ]; then
-            echo "$IP"
-            exit 0
-          fi
-        done
-
-        # Fallback: try DHCP leases
-        INTERFACES=$(virsh -c qemu:///system domiflist "{{ item }}" | awk 'NR>2 && $3 != "" && $5 != "" {print $3, $5}')
-        while IFS= read -r line; do
-          NETWORK=$(echo "$line" | awk '{print $1}')
-          MAC=$(echo "$line" | awk '{print $2}')
-
-          IP=$(virsh -c qemu:///system net-dhcp-leases "$NETWORK" 2>/dev/null | grep -i "$MAC" | awk '{print $5}' | cut -d'/' -f1 | head -n1)
-
-          if [ -n "$IP" ]; then
-            echo "$IP"
-            exit 0
-          fi
-        done <<< "$INTERFACES"
+    - name: Get VM IP addresses from DHCP leases (hostname preferred)
+      script: resolve_vm_ip.sh {{ item | quote }}
       register: vm_ips
       loop: "{{ cluster_vms.stdout_lines }}"
       changed_when: false
@@ -58,7 +30,7 @@
           {% set entries = [] %}
           {% for result in vm_ips.results %}
           {%   set vm_name = result.item %}
-          {%   set ip = result.stdout | trim %}
+          {%   set ip = result.stdout | default('') | trim %}
           {%   if ip | length > 0 %}
           {%     set _ = entries.append({'name': vm_name, 'ip': ip}) %}
           {%   endif %}
@@ -126,12 +98,13 @@
       shell: |
         set -e
         VM_IP="{{ item.ip }}"
-
-        # ssh-keyscan can use bare IP for both IPv4 and IPv6
-        ssh-keyscan -H "$VM_IP" >> ~/.ssh/known_hosts 2>/dev/null || true
-
-        # SSH to bare IP (works for both IPv4 and IPv6)
-        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 core@"$VM_IP" \
+        if echo "$VM_IP" | grep -q ':'; then
+          SSH_HOST="[${VM_IP}]"
+        else
+          SSH_HOST="$VM_IP"
+        fi
+        ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=15 "core@${SSH_HOST}" \
           "echo '{{ local_ssh_pubkey_content }}' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys"
       register: ssh_key_propagation
       changed_when: false


### PR DESCRIPTION
libvirt net-dhcp-leases can show multiple rows per MAC (anonymous DUID vs hostname). Prefer the lease whose Hostname matches the VM (e.g. master-0 for ostest_master_0), then any lease with a hostname, then any lease.

Add roles/common/files/resolve_vm_ip.sh and call it from update-cluster-inventory; use bracketed IPv6 for ssh/ssh-keyscan.

Made-with: Cursor