### PR TITLE
NO-JIRA: feat: added CI token validation step

### DIFF
--- a/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/config.yml
+++ b/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/config.yml
@@ -31,19 +31,14 @@
     - "'registry.ci.openshift.org' in config_content"
     - "'registry.ci.openshift.org' not in (pull_secret_content.auths | default({}) | list)"
 
-- name: Extract CI_TOKEN matches from config file
+- name: Extract CI_TOKEN from config file
   set_fact:
-    ci_token_matches: "{{ config_content | regex_search('(?m)^export CI_TOKEN=\"([^\"]+)\"', '\\1') | default([]) }}"
-  no_log: true
-
-- name: Set CI_TOKEN value
-  set_fact:
-    ci_token: "{{ ci_token_matches | first | default('') }}"
+    ci_token: "{{ config_content | regex_findall('(?m)^export CI_TOKEN=\"([^\"]+)\"') | first | default('', true) }}"
   no_log: true
 
 - name: Extract release image registry
   set_fact:
-    release_registry: "{{ config_content | regex_search('(?m)^export OPENSHIFT_RELEASE_IMAGE=\"?([^/\"]+)', '\\1') | default([]) | first | default('') }}"
+    release_registry: "{{ config_content | regex_findall('(?m)^export OPENSHIFT_RELEASE_IMAGE=\"?([^/\"]+)') | first | default('', true) }}"
   when: ci_token | length > 0
 
 - name: Validate CI token against release image registry
@@ -60,7 +55,7 @@
   no_log: true
   when:
     - ci_token | length > 0
-    - release_registry | default('') is search('ci\.openshift\.org')
+    - release_registry | default('') == 'registry.ci.openshift.org'
 
 - name: Fail fast if CI token is expired or invalid
   fail:

--- a/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/config.yml
+++ b/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/config.yml
@@ -31,6 +31,46 @@
     - "'registry.ci.openshift.org' in config_content"
     - "'registry.ci.openshift.org' not in (pull_secret_content.auths | default({}) | list)"
 
+- name: Extract CI_TOKEN matches from config file
+  set_fact:
+    ci_token_matches: "{{ config_content | regex_search('(?m)^export CI_TOKEN=\"([^\"]+)\"', '\\1') | default([]) }}"
+  no_log: true
+
+- name: Set CI_TOKEN value
+  set_fact:
+    ci_token: "{{ ci_token_matches | first | default('') }}"
+  no_log: true
+
+- name: Extract release image registry
+  set_fact:
+    release_registry: "{{ config_content | regex_search('(?m)^export OPENSHIFT_RELEASE_IMAGE=\"?([^/\"]+)', '\\1') | default([]) | first | default('') }}"
+  when: ci_token | length > 0
+
+- name: Validate CI token against release image registry
+  uri:
+    url: "https://{{ release_registry }}/v2/"
+    headers:
+      Authorization: "Bearer {{ ci_token }}"
+    validate_certs: true
+    status_code: [200]
+  delegate_to: localhost
+  become: false
+  register: ci_login_result
+  ignore_errors: true
+  no_log: true
+  when:
+    - ci_token | length > 0
+    - release_registry | default('') is search('ci\.openshift\.org')
+
+- name: Fail fast if CI token is expired or invalid
+  fail:
+    msg: >-
+      CI token is invalid or expired for {{ release_registry }}.
+      Update CI_TOKEN in {{ config_file[method] }} and retry.
+  when:
+    - ci_login_result is defined
+    - ci_login_result is failed
+
 - name: Copy pull secrets
   copy:
     dest: "{{dev_scripts_path}}/pull_secret.json"


### PR DESCRIPTION
If you are not using a Quay registry but a CI registry image and your token is expired, you will find out quite late in the process. I've added a validation step to fail faster and warn the user about the token expiration