### PR TITLE
Fix Ironic hang on provisioningIP and add clean-spoke target

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -49,6 +49,9 @@ clean:
 full-clean:
 	@./openshift-clusters/scripts/full-clean.sh
 
+clean-spoke:
+	@./openshift-clusters/scripts/clean-spoke.sh
+
 ssh:
 	@./aws-hypervisor/scripts/ssh.sh
 
@@ -119,6 +122,7 @@ help:
 	@echo "  startup-cluster      - Start up OpenShift cluster VMs and proxy container"
 	@echo "  clean                - Clean OpenShift cluster using dev-scripts clean target"
 	@echo "  full-clean           - Fully clean instance cache and OpenShift cluster using dev-scripts realclean target"
+	@echo "  clean-spoke          - Clean spoke cluster resources (VMs, network, auth) from assisted installer"
 	@echo "  patch-nodes          - Build resource-agents RPM and patch cluster nodes (default version: 4.11)"
 	@echo ""
 	@echo "Cluster Utilities:"

--- a/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
+++ b/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
@@ -22,7 +22,10 @@
     - provisioningInterface
   register: remove_result
   changed_when: "'patched' in remove_result.stdout"
-  failed_when: false
+  failed_when: >-
+    remove_result.rc != 0 and
+    'does not exist' not in remove_result.stderr and
+    'does not exist' not in remove_result.stdout
 
 - name: Wait for metal3 pod to stabilize after provisioning change
   shell: |
@@ -44,9 +47,12 @@
 - name: Remove provisioningIP again if still present
   shell: |
     oc patch provisioning provisioning-configuration --type=json \
-      -p '[{"op":"remove","path":"/spec/provisioningIP"}]'
+      -p '[{"op":"remove","path":"/spec/provisioningIP"}]' 2>&1
   when: prov_ip_check.stdout | length > 0
   register: prov_ip_retry
+  failed_when: >-
+    prov_ip_retry.rc != 0 and
+    'does not exist' not in prov_ip_retry.stdout
 
 - name: Wait for metal3 pod restart after provisioningIP retry
   shell: |
@@ -64,6 +70,10 @@
     METAL3_POD=$(oc get pods -n openshift-machine-api \
       -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state \
       --no-headers 2>/dev/null | grep -v Terminating | awk '{print $1}')
+    if [ -z "$METAL3_POD" ]; then
+      echo "WAITING: metal3 pod not found yet"
+      exit 1
+    fi
     LOGS=$(oc logs -n openshift-machine-api "$METAL3_POD" \
       -c metal3-httpd --tail=3 2>/dev/null)
     if echo "$LOGS" | grep -q "Waiting for .* to be configured"; then
@@ -73,7 +83,7 @@
     echo "OK: httpd is running"
   register: ironic_health
   until: ironic_health.rc == 0
-  retries: 20
+  retries: "{{ (metal3_stabilize_timeout / 15) | int }}"
   delay: 15
 
 - name: Display metal3 pod status

--- a/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
+++ b/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
@@ -50,6 +50,7 @@
       -p '[{"op":"remove","path":"/spec/provisioningIP"}]' 2>&1
   when: prov_ip_check.stdout | length > 0
   register: prov_ip_retry
+  changed_when: "'patched' in prov_ip_retry.stdout"
   failed_when: >-
     prov_ip_retry.rc != 0 and
     'does not exist' not in prov_ip_retry.stdout

--- a/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
+++ b/deploy/openshift-clusters/roles/assisted/acm-install/tasks/enable-watch-all-namespaces.yml
@@ -14,18 +14,15 @@
 - name: Remove leftover provisioning fields from Provisioning CR
   shell: |
     oc patch provisioning provisioning-configuration --type=json \
-      -p '[
-        {"op":"remove","path":"/spec/provisioningIP"},
-        {"op":"remove","path":"/spec/provisioningDHCPRange"},
-        {"op":"remove","path":"/spec/provisioningNetworkCIDR"},
-        {"op":"remove","path":"/spec/provisioningInterface"}
-      ]' 2>&1
+      -p '[{"op":"remove","path":"/spec/{{ item }}"}]' 2>&1
+  loop:
+    - provisioningIP
+    - provisioningDHCPRange
+    - provisioningNetworkCIDR
+    - provisioningInterface
   register: remove_result
   changed_when: "'patched' in remove_result.stdout"
-  failed_when: >-
-    remove_result.rc != 0 and
-    'does not exist' not in remove_result.stderr and
-    'does not exist' not in remove_result.stdout
+  failed_when: false
 
 - name: Wait for metal3 pod to stabilize after provisioning change
   shell: |
@@ -35,6 +32,48 @@
   register: metal3_pod
   until: metal3_pod.rc == 0
   retries: "{{ (metal3_stabilize_timeout / 15) | int }}"
+  delay: 15
+
+- name: Verify provisioningIP was actually removed
+  shell: |
+    oc get provisioning provisioning-configuration \
+      -o jsonpath='{.spec.provisioningIP}' 2>/dev/null
+  register: prov_ip_check
+  changed_when: false
+
+- name: Remove provisioningIP again if still present
+  shell: |
+    oc patch provisioning provisioning-configuration --type=json \
+      -p '[{"op":"remove","path":"/spec/provisioningIP"}]'
+  when: prov_ip_check.stdout | length > 0
+  register: prov_ip_retry
+
+- name: Wait for metal3 pod restart after provisioningIP retry
+  shell: |
+    oc get pods -n openshift-machine-api \
+      -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state \
+      --no-headers 2>/dev/null | grep -v Terminating | grep -q Running
+  register: metal3_pod_retry
+  until: metal3_pod_retry.rc == 0
+  retries: "{{ (metal3_stabilize_timeout / 15) | int }}"
+  delay: 15
+  when: prov_ip_retry is changed
+
+- name: Verify Ironic httpd is not stuck waiting for provisioningIP
+  shell: |
+    METAL3_POD=$(oc get pods -n openshift-machine-api \
+      -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state \
+      --no-headers 2>/dev/null | grep -v Terminating | awk '{print $1}')
+    LOGS=$(oc logs -n openshift-machine-api "$METAL3_POD" \
+      -c metal3-httpd --tail=3 2>/dev/null)
+    if echo "$LOGS" | grep -q "Waiting for .* to be configured"; then
+      echo "BLOCKED: httpd waiting for provisioningIP"
+      exit 1
+    fi
+    echo "OK: httpd is running"
+  register: ironic_health
+  until: ironic_health.rc == 0
+  retries: 20
   delay: 15
 
 - name: Display metal3 pod status

--- a/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
+++ b/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
@@ -18,7 +18,7 @@
   when: has_cluster_vms | bool
   block:
     - name: Get VM IP addresses from DHCP leases (hostname preferred)
-      script: resolve_vm_ip.sh {{ item | quote }}
+      script: "{{ role_path | default(playbook_dir + '/roles/common') }}/files/resolve_vm_ip.sh {{ item | quote }}"
       register: vm_ips
       loop: "{{ cluster_vms.stdout_lines }}"
       changed_when: false

--- a/deploy/openshift-clusters/scripts/clean-spoke.sh
+++ b/deploy/openshift-clusters/scripts/clean-spoke.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(dirname "$0")
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 set -o nounset
+set -o errexit
 set -o pipefail
 
 # Source instance.env for SSH_PUBLIC_KEY and other settings
@@ -22,7 +23,7 @@ fi
 # Parse spoke_cluster_name from vars/assisted.yml
 SPOKE_CLUSTER_NAME="spoke-tnf"
 if [[ -f "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" ]]; then
-    PARSED_NAME=$(grep '^spoke_cluster_name:' "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" | awk '{print $2}' | tr -d '"' | tr -d "'")
+    PARSED_NAME=$(grep '^spoke_cluster_name:' "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" | awk '{print $2}' | tr -d '"' | tr -d "'" || true)
     if [[ -n "${PARSED_NAME}" ]]; then
         SPOKE_CLUSTER_NAME="${PARSED_NAME}"
     fi

--- a/deploy/openshift-clusters/scripts/clean-spoke.sh
+++ b/deploy/openshift-clusters/scripts/clean-spoke.sh
@@ -28,6 +28,11 @@ if [[ -f "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" ]]; then
     fi
 fi
 
+if [[ ! "${SPOKE_CLUSTER_NAME}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+    echo "Error: Invalid spoke_cluster_name '${SPOKE_CLUSTER_NAME}'."
+    exit 1
+fi
+
 # Derive the libvirt network bridge name from the cluster name
 SPOKE_NETWORK="${SPOKE_CLUSTER_NAME}"
 
@@ -48,6 +53,11 @@ fi
 SSH_CMD="ssh ${SSH_KEY_OPT} -o ConnectTimeout=10 -o StrictHostKeyChecking=no ${SSH_USER}@${INSTANCE_IP}"
 
 echo "Cleaning spoke cluster '${SPOKE_CLUSTER_NAME}' resources..."
+
+if ! ${SSH_CMD} "true" >/dev/null 2>&1; then
+    echo "Error: Unable to connect to ${SSH_USER}@${INSTANCE_IP}."
+    exit 1
+fi
 
 # Find and destroy spoke VMs
 echo ""

--- a/deploy/openshift-clusters/scripts/clean-spoke.sh
+++ b/deploy/openshift-clusters/scripts/clean-spoke.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Clean spoke cluster resources (VMs, network, auth) created by assisted installer
+# This is the counterpart to deploy-fencing-assisted.sh
+
+SCRIPT_DIR=$(dirname "$0")
+DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+set -o nounset
+set -o pipefail
+
+# Source instance.env for SSH_PUBLIC_KEY and other settings
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
+
+# Check if instance data exists
+if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+    echo "Error: No instance found. Please run 'make deploy' first."
+    exit 1
+fi
+
+# Parse spoke_cluster_name from vars/assisted.yml
+SPOKE_CLUSTER_NAME="spoke-tnf"
+if [[ -f "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" ]]; then
+    PARSED_NAME=$(grep '^spoke_cluster_name:' "${DEPLOY_DIR}/openshift-clusters/vars/assisted.yml" | awk '{print $2}' | tr -d '"' | tr -d "'")
+    if [[ -n "${PARSED_NAME}" ]]; then
+        SPOKE_CLUSTER_NAME="${PARSED_NAME}"
+    fi
+fi
+
+# Derive the libvirt network bridge name from the cluster name
+SPOKE_NETWORK="${SPOKE_CLUSTER_NAME}"
+
+# Get SSH connection info
+INSTANCE_IP=$(cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/public_address" 2>/dev/null)
+SSH_USER=$(cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/ssh_user" 2>/dev/null || echo "ec2-user")
+
+if [[ -z "${INSTANCE_IP}" ]]; then
+    echo "Error: Could not determine instance IP."
+    exit 1
+fi
+
+SSH_KEY_OPT=""
+if [[ -n "${SSH_PUBLIC_KEY:-}" ]]; then
+    SSH_KEY_OPT="-i ${SSH_PUBLIC_KEY%.pub}"
+fi
+
+SSH_CMD="ssh ${SSH_KEY_OPT} -o ConnectTimeout=10 -o StrictHostKeyChecking=no ${SSH_USER}@${INSTANCE_IP}"
+
+echo "Cleaning spoke cluster '${SPOKE_CLUSTER_NAME}' resources..."
+
+# Find and destroy spoke VMs
+echo ""
+echo "--- Removing spoke VMs ---"
+SPOKE_VMS=$(${SSH_CMD} "sudo virsh list --all --name 2>/dev/null | grep '^${SPOKE_CLUSTER_NAME}-'" 2>/dev/null || true)
+if [[ -n "${SPOKE_VMS}" ]]; then
+    for vm in ${SPOKE_VMS}; do
+        echo "Destroying VM: ${vm}"
+        ${SSH_CMD} "sudo virsh destroy '${vm}' 2>/dev/null; sudo virsh undefine '${vm}' --remove-all-storage --nvram 2>/dev/null" || true
+    done
+else
+    echo "No spoke VMs found."
+fi
+
+# Remove spoke network
+echo ""
+echo "--- Removing spoke network ---"
+NET_EXISTS=$(${SSH_CMD} "sudo virsh net-list --all --name 2>/dev/null | grep '^${SPOKE_NETWORK}$'" 2>/dev/null || true)
+if [[ -n "${NET_EXISTS}" ]]; then
+    echo "Removing network: ${SPOKE_NETWORK}"
+    ${SSH_CMD} "sudo virsh net-destroy '${SPOKE_NETWORK}' 2>/dev/null; sudo virsh net-undefine '${SPOKE_NETWORK}' 2>/dev/null" || true
+else
+    echo "No spoke network found."
+fi
+
+# Remove spoke auth directory
+echo ""
+echo "--- Removing spoke credentials ---"
+${SSH_CMD} "rm -rf ~/${SPOKE_CLUSTER_NAME}" 2>/dev/null || true
+echo "Removed ~/${SPOKE_CLUSTER_NAME}"
+
+# Remove any stale symlinks in libvirt images
+echo ""
+echo "--- Cleaning stale symlinks ---"
+${SSH_CMD} "sudo find /var/lib/libvirt/images/ -name '${SPOKE_CLUSTER_NAME}-*' -type l -delete 2>/dev/null" || true
+
+echo ""
+echo "✓ Spoke cluster '${SPOKE_CLUSTER_NAME}' cleanup completed."


### PR DESCRIPTION
## Summary

- Fix Ironic hanging during assisted installer spoke deployment when `provisioningIP` persists after switching `provisioningNetwork` to `Disabled`
- Add verification and retry logic for `provisioningIP` removal, plus a health check on `metal3-httpd`
- Fix `resolve_vm_ip.sh` path resolution in `update-cluster-inventory.yml`
- Add `make clean-spoke` target to clean up spoke cluster resources (VMs, network, credentials)

## Problem

During Deploy of [OCPEDGE-2029](https://redhat.atlassian.net/browse/OCPEDGE-2029) (assisted installer TNF verification), Ironic hung waiting for `provisioningIP` (172.22.0.3) after `provisioningNetwork: Disabled` was set on the Provisioning CR. The `metal3-httpd` container was stuck with `"Waiting for provisioningIP to be configured"`, blocking the spoke deployment.

The root cause was that the batch JSON patch to remove provisioning fields could partially fail silently — if any one field didn't exist, the entire patch was skipped, leaving `provisioningIP` in place.

## Fix

- Patch provisioning fields one at a time via a loop instead of a single batch operation, so each removal is independent
- Add a verification step that re-checks whether `provisioningIP` was actually removed, and retries if not
- Add a health check that detects if `metal3-httpd` is stuck waiting, with retries

## Test plan

- [ ] Deploy spoke TNF cluster via assisted installer (`make deploy fencing-assisted`) and verify metal3 pod stabilizes without hanging
- [ ] Run `make clean-spoke` to verify spoke cleanup works
- [ ] Redeploy spoke after cleanup to confirm clean state

Ref: [OCPEDGE-2029](https://redhat.atlassian.net/browse/OCPEDGE-2029)