### PR TITLE
OCPEDGE-2608: aws-hypervisor: split CF template into network and compute stacks

### DIFF
--- a/deploy/aws-hypervisor/scripts/create.sh
+++ b/deploy/aws-hypervisor/scripts/create.sh
@@ -90,7 +90,7 @@ if [[ "$EC2_INSTANCE_TYPE" =~ c[0-9]+[a-z]*.metal ]]; then
 fi
 
 echo -e "==== Creating network stack ===="
-echo "${NETWORK_STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
+echo "${STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
 aws --region "$REGION" cloudformation create-stack \
     --stack-name "${NETWORK_STACK_NAME}" \
     --template-body "file://${TEMPLATES_DIR}/network-stack.yaml" \
@@ -106,7 +106,7 @@ aws --region "${REGION}" cloudformation wait stack-create-complete \
 echo "${NETWORK_STACK_NAME}" > "${SCRIPT_DIR}/../${SHARED_DIR}/network_stack_name"
 
 echo -e "==== Creating compute stack ===="
-echo "${STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
+echo "${NETWORK_STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
 aws --region "$REGION" cloudformation create-stack \
     --stack-name "${STACK_NAME}" \
     --template-body "file://${TEMPLATES_DIR}/compute-stack.yaml" \

--- a/deploy/aws-hypervisor/scripts/create.sh
+++ b/deploy/aws-hypervisor/scripts/create.sh
@@ -28,12 +28,18 @@ function cleanup_capacity_on_error() {
 
 mkdir -p "${SCRIPT_DIR}/../${SHARED_DIR}"
 
-cf_tpl_file="${SCRIPT_DIR}/../${SHARED_DIR}/${STACK_NAME}-cf-tpl.yaml"
+NETWORK_STACK_NAME="${STACK_NAME}-network"
+TEMPLATES_DIR="${SCRIPT_DIR}/../templates"
 
 function save_stack_events()
 {
   set +o errexit
-  aws --region "${REGION}" cloudformation describe-stack-events --stack-name "${STACK_NAME}" --output json > "${SCRIPT_DIR}/../${SHARED_DIR}/stack-events-${STACK_NAME}.json"
+  aws --region "${REGION}" cloudformation describe-stack-events \
+      --stack-name "${STACK_NAME}" --output json \
+      > "${SCRIPT_DIR}/../${SHARED_DIR}/stack-events-${STACK_NAME}.json" 2>/dev/null
+  aws --region "${REGION}" cloudformation describe-stack-events \
+      --stack-name "${NETWORK_STACK_NAME}" --output json \
+      > "${SCRIPT_DIR}/../${SHARED_DIR}/stack-events-${NETWORK_STACK_NAME}.json" 2>/dev/null
   set -o errexit
 }
 
@@ -83,28 +89,39 @@ if [[ "$EC2_INSTANCE_TYPE" =~ c[0-9]+[a-z]*.metal ]]; then
   ec2Type="MetalMachine"
 fi
 
-# Copy CloudFormation template from templates directory
-cp "${SCRIPT_DIR}/../templates/rhel-instance.yaml" "${cf_tpl_file}"
-
-
-echo -e "==== Start to create rhel host ===="
-echo "${STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
-aws --region "$REGION" cloudformation create-stack --stack-name "${STACK_NAME}" \
-    --template-body "file://${cf_tpl_file}" \
+echo -e "==== Creating network stack ===="
+echo "${NETWORK_STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
+aws --region "$REGION" cloudformation create-stack \
+    --stack-name "${NETWORK_STACK_NAME}" \
+    --template-body "file://${TEMPLATES_DIR}/network-stack.yaml" \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-cli-pager \
     --parameters \
-        "ParameterKey=HostInstanceType,ParameterValue=${EC2_INSTANCE_TYPE}"  \
-        "ParameterKey=Machinename,ParameterValue=${STACK_NAME}"  \
+        "ParameterKey=AvailabilityZone,ParameterValue=${AVAILABILITY_ZONE}"
+
+echo "Waiting for network stack..."
+aws --region "${REGION}" cloudformation wait stack-create-complete \
+    --stack-name "${NETWORK_STACK_NAME}"
+
+echo "${NETWORK_STACK_NAME}" > "${SCRIPT_DIR}/../${SHARED_DIR}/network_stack_name"
+
+echo -e "==== Creating compute stack ===="
+echo "${STACK_NAME}" >> "${SCRIPT_DIR}/../${SHARED_DIR}/to_be_removed_cf_stack_list"
+aws --region "$REGION" cloudformation create-stack \
+    --stack-name "${STACK_NAME}" \
+    --template-body "file://${TEMPLATES_DIR}/compute-stack.yaml" \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --no-cli-pager \
+    --parameters \
+        "ParameterKey=NetworkStackName,ParameterValue=${NETWORK_STACK_NAME}" \
+        "ParameterKey=HostInstanceType,ParameterValue=${EC2_INSTANCE_TYPE}" \
+        "ParameterKey=Machinename,ParameterValue=${STACK_NAME}" \
         "ParameterKey=AmiId,ParameterValue=${RHEL_HOST_AMI}" \
         "ParameterKey=EC2Type,ParameterValue=${ec2Type}" \
         "ParameterKey=PublicKeyString,ParameterValue=$(cat "${SSH_PUBLIC_KEY}")" \
-        "ParameterKey=CapacityReservationId,ParameterValue=${CAPACITY_RESERVATION_ID}" \
-        "ParameterKey=AvailabilityZone,ParameterValue=${AVAILABILITY_ZONE}"
+        "ParameterKey=CapacityReservationId,ParameterValue=${CAPACITY_RESERVATION_ID}"
 
-echo "Created stack"
-
-echo "Waiting for stack"
+echo "Waiting for compute stack..."
 aws --region "${REGION}" cloudformation wait stack-create-complete --stack-name "${STACK_NAME}"
 
 echo "$STACK_NAME" > "${SCRIPT_DIR}/../${SHARED_DIR}/rhel_host_stack_name"

--- a/deploy/aws-hypervisor/scripts/destroy.sh
+++ b/deploy/aws-hypervisor/scripts/destroy.sh
@@ -8,34 +8,46 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if instance data directory exists and has the required files
 instance_data_dir="${SCRIPT_DIR}/../${SHARED_DIR}"
 public_address_file="${instance_data_dir}/public_address"
 ssh_user_file="${instance_data_dir}/ssh_user"
+network_stack_name_file="${instance_data_dir}/network_stack_name"
+NETWORK_STACK_NAME="${STACK_NAME}-network"
 
 # Check if we have a deployed instance
 if [[ ! -f "$public_address_file" ]] || [[ ! -f "$ssh_user_file" ]]; then
     echo "No deployed instance found (missing instance data files)."
-    echo "Checking if CloudFormation stack '${STACK_NAME}' exists..."
-    
-    # Check if the stack exists in CloudFormation
+    echo "Checking if CloudFormation stacks exist..."
+
+    compute_exists=false
+    network_exists=false
     if aws --region "$REGION" cloudformation describe-stacks --stack-name "${STACK_NAME}" &>/dev/null; then
-        echo "Found CloudFormation stack '${STACK_NAME}' - proceeding with stack deletion only."
-    else
-        echo "No CloudFormation stack '${STACK_NAME}' found either."
-        echo "Nothing to destroy."
+        compute_exists=true
+    fi
+    if [[ -f "$network_stack_name_file" ]]; then
+        NETWORK_STACK_NAME=$(cat "$network_stack_name_file")
+    fi
+    if aws --region "$REGION" cloudformation describe-stacks --stack-name "${NETWORK_STACK_NAME}" &>/dev/null; then
+        network_exists=true
+    fi
+
+    if [[ "$compute_exists" == "false" ]] && [[ "$network_exists" == "false" ]]; then
+        echo "No CloudFormation stacks found. Nothing to destroy."
         exit 0
     fi
 else
-    # Instance data exists, proceed with full cleanup
     echo "Found deployed instance, proceeding with cleanup..."
-    
+
     instance_ip=$(cat "$public_address_file")
     host=$(cat "$ssh_user_file")
     ssh_host_ip="$host@$instance_ip"
-    
+
     echo "Unregistering subscription manager on instance..."
     ssh "$ssh_host_ip" "sudo subscription-manager unregister" || echo "Warning: Failed to unregister subscription manager (instance may be unreachable or not registered)"
+
+    if [[ -f "$network_stack_name_file" ]]; then
+        NETWORK_STACK_NAME=$(cat "$network_stack_name_file")
+    fi
 fi
 
 # Cancel capacity reservation if it exists
@@ -45,18 +57,27 @@ if [[ -f "${reservation_file}" ]]; then
     if [[ -n "${reservation_id}" && "${reservation_id}" != "null" ]]; then
         cancel_capacity_reservation "${reservation_id}" "${REGION}"
     fi
-    # Clean up capacity reservation files
     rm -f "${reservation_file}"
     rm -f "${instance_data_dir}/availability-zone"
 fi
 
-# Delete the CloudFormation stack
-echo "Deleting CloudFormation stack '${STACK_NAME}'..."
-aws --region "$REGION" cloudformation delete-stack --stack-name "${STACK_NAME}"
+# Delete compute stack first (CF prevents deleting network while its exports are imported)
+if aws --region "$REGION" cloudformation describe-stacks --stack-name "${STACK_NAME}" &>/dev/null; then
+    echo "Deleting compute stack '${STACK_NAME}'..."
+    aws --region "$REGION" cloudformation delete-stack --stack-name "${STACK_NAME}"
+    echo "Waiting for compute stack deletion..."
+    aws --region "$REGION" cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" &
+    wait "$!"
+fi
 
-echo "Waiting for stack $STACK_NAME to be deleted..."
-aws --region "$REGION" cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" &
-wait "$!"
+# Delete network stack
+if aws --region "$REGION" cloudformation describe-stacks --stack-name "${NETWORK_STACK_NAME}" &>/dev/null; then
+    echo "Deleting network stack '${NETWORK_STACK_NAME}'..."
+    aws --region "$REGION" cloudformation delete-stack --stack-name "${NETWORK_STACK_NAME}"
+    echo "Waiting for network stack deletion..."
+    aws --region "$REGION" cloudformation wait stack-delete-complete --stack-name "${NETWORK_STACK_NAME}" &
+    wait "$!"
+fi
 
 # Clean up instance data directory
 if [[ -d "$instance_data_dir" ]]; then
@@ -64,5 +85,5 @@ if [[ -d "$instance_data_dir" ]]; then
     rm -rf "${instance_data_dir:?}/"*
 fi
 
-echo "Stack ${STACK_NAME} has been successfully deleted." > "${instance_data_dir}/.done"
+echo "Stacks deleted successfully." > "${instance_data_dir}/.done"
 echo "Destroy operation completed successfully."

--- a/deploy/aws-hypervisor/scripts/destroy.sh
+++ b/deploy/aws-hypervisor/scripts/destroy.sh
@@ -66,8 +66,12 @@ if aws --region "$REGION" cloudformation describe-stacks --stack-name "${STACK_N
     echo "Deleting compute stack '${STACK_NAME}'..."
     aws --region "$REGION" cloudformation delete-stack --stack-name "${STACK_NAME}"
     echo "Waiting for compute stack deletion..."
-    aws --region "$REGION" cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" &
-    wait "$!"
+    if ! { aws --region "$REGION" cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" & wait "$!"; }; then
+        echo "ERROR: Compute stack deletion failed or timed out." >&2
+        echo "Network stack '${NETWORK_STACK_NAME}' was NOT deleted." >&2
+        echo "Check the AWS CloudFormation console for details." >&2
+        exit 1
+    fi
 fi
 
 # Delete network stack

--- a/deploy/aws-hypervisor/templates/compute-stack.yaml
+++ b/deploy/aws-hypervisor/templates/compute-stack.yaml
@@ -60,7 +60,7 @@ Resources:
     Properties:
       ImageId: !Ref AmiId
       IamInstanceProfile: !ImportValue
-        Fn::Sub: "${NetworkStackName}-InstanceProfileArn"
+        Fn::Sub: "${NetworkStackName}-InstanceProfileName"
       InstanceType: !Ref HostInstanceType
       LaunchTemplate: !If
         - UseCapacityReservation

--- a/deploy/aws-hypervisor/templates/compute-stack.yaml
+++ b/deploy/aws-hypervisor/templates/compute-stack.yaml
@@ -1,0 +1,140 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Per-instance compute resources for RHEL hypervisor.
+  Imports shared network infrastructure from a network stack via cross-stack references.
+
+Conditions:
+  AddSecondaryVolume: !Not [!Equals [!Ref EC2Type, 'MetalMachine']]
+  UseCapacityReservation: !Not [!Equals [!Ref CapacityReservationId, '']]
+
+Mappings:
+  VolumeSize:
+    MetalMachine:
+      PrimaryVolumeSize: "300"
+      SecondaryVolumeSize: "0"
+    VirtualMachine:
+      PrimaryVolumeSize: "200"
+      SecondaryVolumeSize: "100"
+
+Parameters:
+  NetworkStackName:
+    Description: Name of the network stack whose exports this stack imports
+    Type: String
+  EC2Type:
+    Default: 'VirtualMachine'
+    Type: String
+  AmiId:
+    Description: Current RHEL AMI to use.
+    Type: AWS::EC2::Image::Id
+  Machinename:
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: Machinename
+    Description: Machinename
+    Type: String
+    Default: rhel-testbed-ec2-instance
+  HostInstanceType:
+    Default: t2.medium
+    Type: String
+  PublicKeyString:
+    Type: String
+    Description: The public key used to connect to the EC2 instance
+  CapacityReservationId:
+    Type: String
+    Description: EC2 Capacity Reservation ID (optional)
+    Default: ""
+
+Resources:
+  RHELLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Condition: UseCapacityReservation
+    Properties:
+      LaunchTemplateData:
+        CapacityReservationSpecification:
+          CapacityReservationTarget:
+            CapacityReservationId: !Ref CapacityReservationId
+
+  RHELInstance:
+    Type: AWS::EC2::Instance
+    DeletionPolicy: Delete
+    Properties:
+      ImageId: !Ref AmiId
+      IamInstanceProfile: !ImportValue
+        Fn::Sub: "${NetworkStackName}-InstanceProfileArn"
+      InstanceType: !Ref HostInstanceType
+      LaunchTemplate: !If
+        - UseCapacityReservation
+        - LaunchTemplateId: !Ref RHELLaunchTemplate
+          Version: !GetAtt RHELLaunchTemplate.LatestVersionNumber
+        - !Ref AWS::NoValue
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: "False"
+          DeviceIndex: "0"
+          GroupSet:
+            - !ImportValue
+                Fn::Sub: "${NetworkStackName}-SGId"
+          SubnetId: !ImportValue
+            Fn::Sub: "${NetworkStackName}-SubnetId"
+      Tags:
+        - Key: Name
+          Value: !Join ["", [!Ref Machinename]]
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: !FindInMap [VolumeSize, !Ref EC2Type, PrimaryVolumeSize]
+            VolumeType: gp3
+            Iops: 16000
+        - !If
+          - AddSecondaryVolume
+          - DeviceName: /dev/sdc
+            Ebs:
+              VolumeSize: !FindInMap [VolumeSize, !Ref EC2Type, SecondaryVolumeSize]
+              VolumeType: gp3
+              Iops: 16000
+          - !Ref AWS::NoValue
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash -xe
+
+          log_output_file=/tmp/init_output.txt
+
+          echo "====== Authorizing public key ======" | tee -a "$log_output_file"
+          echo "${PublicKeyString}" >> /home/ec2-user/.ssh/authorized_keys
+
+          sudo dnf install -y git make cockpit lvm2 jq |& tee -a "$log_output_file"
+          sudo systemctl enable --now cockpit.socket |& tee -a "$log_output_file"
+
+          echo "====== Getting Disk Path ======" | tee -a "$log_output_file"
+          pv_location=$(sudo lsblk -Jd | jq -r '.blockdevices[] | select(.size == "200G") | "/dev/\(.name)"')
+          echo "discovered pv location of ($pv_location)" | tee -a "$log_output_file"
+
+          echo "====== Creating PV ======" | tee -a "$log_output_file"
+          sudo pvcreate "$pv_location" |& tee -a "$log_output_file"
+
+          echo "====== Creating VG ======" | tee -a "$log_output_file"
+          sudo vgcreate rhel "$pv_location" |& tee -a "$log_output_file"
+
+  RHELElasticIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Ref Machinename
+
+  RHELEIPAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      InstanceId: !Ref RHELInstance
+      AllocationId: !GetAtt RHELElasticIP.AllocationId
+
+Outputs:
+  InstanceId:
+    Description: RHEL Host Instance ID
+    Value: !Ref RHELInstance
+  PrivateIp:
+    Description: The bastion host Private DNS, will be used for cluster install pulling release image
+    Value: !GetAtt RHELInstance.PrivateIp
+  PublicIp:
+    Description: The bastion host Public IP, will be used for registering minIO server DNS
+    Value: !GetAtt RHELInstance.PublicIp

--- a/deploy/aws-hypervisor/templates/network-stack.yaml
+++ b/deploy/aws-hypervisor/templates/network-stack.yaml
@@ -185,8 +185,8 @@ Outputs:
     Value: !GetAtt RHELSecurityGroup.GroupId
     Export:
       Name: !Sub "${AWS::StackName}-SGId"
-  InstanceProfileArn:
+  InstanceProfileName:
     Description: IAM instance profile for compute instances
-    Value: !GetAtt RHELInstanceProfile.Arn
+    Value: !Ref RHELInstanceProfile
     Export:
-      Name: !Sub "${AWS::StackName}-InstanceProfileArn"
+      Name: !Sub "${AWS::StackName}-InstanceProfileName"

--- a/deploy/aws-hypervisor/templates/network-stack.yaml
+++ b/deploy/aws-hypervisor/templates/network-stack.yaml
@@ -187,6 +187,6 @@ Outputs:
       Name: !Sub "${AWS::StackName}-SGId"
   InstanceProfileArn:
     Description: IAM instance profile for compute instances
-    Value: !Ref RHELInstanceProfile
+    Value: !GetAtt RHELInstanceProfile.Arn
     Export:
       Name: !Sub "${AWS::StackName}-InstanceProfileArn"

--- a/deploy/aws-hypervisor/templates/network-stack.yaml
+++ b/deploy/aws-hypervisor/templates/network-stack.yaml
@@ -1,0 +1,192 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Shared network infrastructure for RHEL hypervisor instances.
+  Created once per environment, referenced by compute stacks via cross-stack exports.
+
+Conditions:
+  UseSpecificAZ: !Not [!Equals [!Ref AvailabilityZone, '']]
+
+Parameters:
+  VpcCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.192.0.0/16
+    Description: CIDR block for VPC.
+    Type: String
+  PublicSubnetCidr:
+    Description: IP range (CIDR notation) for the public subnet in the first Availability Zone
+    Type: String
+    Default: 10.192.10.0/24
+  AvailabilityZone:
+    Type: String
+    Description: Specific AZ for subnet placement (optional, from capacity reservation)
+    Default: ""
+
+Resources:
+  RHELVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      Tags:
+        - Key: Name
+          Value: RHELVPC
+
+  RHELInternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DeletionPolicy: Delete
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RHELInternetGateway
+
+  RHELGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    DeletionPolicy: Delete
+    Properties:
+      VpcId: !Ref RHELVPC
+      InternetGatewayId: !Ref RHELInternetGateway
+
+  RHELPublicSubnet:
+    Type: AWS::EC2::Subnet
+    DeletionPolicy: Delete
+    Properties:
+      VpcId: !Ref RHELVPC
+      CidrBlock: !Ref PublicSubnetCidr
+      MapPublicIpOnLaunch: true
+      AvailabilityZone: !If [UseSpecificAZ, !Ref AvailabilityZone, !Ref 'AWS::NoValue']
+      Tags:
+        - Key: Name
+          Value: RHELPublicSubnet
+
+  RHELNatGatewayEIP:
+    Type: AWS::EC2::EIP
+    DeletionPolicy: Delete
+    DependsOn: RHELGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  RHELNatGateway:
+    Type: AWS::EC2::NatGateway
+    DeletionPolicy: Delete
+    DependsOn: RHELNatGatewayEIP
+    Properties:
+      AllocationId: !GetAtt RHELNatGatewayEIP.AllocationId
+      SubnetId: !Ref RHELPublicSubnet
+
+  RHELRouteTable:
+    Type: AWS::EC2::RouteTable
+    DeletionPolicy: Delete
+    Properties:
+      VpcId: !Ref RHELVPC
+      Tags:
+        - Key: Name
+          Value: RHELRouteTable
+
+  RHELPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: RHELGatewayAttachment
+    Properties:
+      RouteTableId: !Ref RHELRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref RHELInternetGateway
+
+  RHELPublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: RHELRouteTable
+    Properties:
+      RouteTableId: !Ref RHELRouteTable
+      SubnetId: !Ref RHELPublicSubnet
+
+  RHELIamRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Delete
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+
+  RHELInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+        - !Ref RHELIamRole
+
+  RHELSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: RHEL Host Security Group
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 5678
+          ToPort: 5678
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 9090
+          ToPort: 9090
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 5353
+          ToPort: 5353
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 6443
+          ToPort: 6443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 8213
+          ToPort: 8213
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 30000
+          ToPort: 32767
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: udp
+          FromPort: 30000
+          ToPort: 32767
+          CidrIp: 0.0.0.0/0
+      VpcId: !Ref RHELVPC
+
+Outputs:
+  SubnetId:
+    Description: Public subnet for compute instances
+    Value: !Ref RHELPublicSubnet
+    Export:
+      Name: !Sub "${AWS::StackName}-SubnetId"
+  SGId:
+    Description: Security group for compute instances
+    Value: !GetAtt RHELSecurityGroup.GroupId
+    Export:
+      Name: !Sub "${AWS::StackName}-SGId"
+  InstanceProfileArn:
+    Description: IAM instance profile for compute instances
+    Value: !Ref RHELInstanceProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-InstanceProfileArn"


### PR DESCRIPTION
## Summary

- Splits `rhel-instance.yaml` into `network-stack.yaml` (shared VPC/subnet/SG/IAM) and `compute-stack.yaml` (per-instance EC2/EIP) using CF cross-stack exports/imports
- Updates `create.sh` for sequential two-stack creation (network first, then compute) with dual stack event capture
- Updates `destroy.sh` for ordered deletion (compute first, then network) with backward compat for pre-split deployments

Groundwork for multi-node provisioning — no user-facing behavior change for single-node deployments.

Ref: [OCPEDGE-2608](https://issues.redhat.com/browse/OCPEDGE-2608)

## Test plan

- [x] Fresh `make create` — verify two stacks appear in AWS CloudFormation console
- [x] Verify instance-data files written: `network_stack_name`, `aws-instance-id`, `public_address`, `private_address`
- [x] `make ssh` into instance
- [x] `make destroy` — verify compute deleted first, then network
- [x] Re-run `make destroy` — should exit cleanly ("Nothing to destroy")
- [x] Test with capacity reservation enabled (`ENABLE_CAPACITY_RESERVATION=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now creates a dedicated network stack plus a separate per-instance compute stack, provisioning shared VPC/subnet/security and per-host compute resources (instance, IP, volumes) and exporting network identifiers for reuse.
  * Compute provisioning accepts network stack linkage and prepares instances with automatic initialization of services and storage.

* **Bug Fixes / Cleanup**
  * Improved teardown: compute stack is removed before network stack with stronger existence checks; capacity reservations and related markers are cleaned up and run completion is clearly recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->