### PR TITLE
openshift-clusters: source common.sh for centralized node-dir resolution

### DIFF
--- a/deploy/aws-hypervisor/scripts/common.sh
+++ b/deploy/aws-hypervisor/scripts/common.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 SCRIPT_DIR=$(dirname "$0")
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
-source "${SCRIPT_DIR}/../instance.env"
+source "${COMMON_DIR}/../instance.env"
 
 # Set defaults
 export STACK_NAME="${STACK_NAME:-${USER}-dev}"
@@ -17,14 +18,13 @@ export CAPACITY_RESERVATION_DURATION_MINUTES="${CAPACITY_RESERVATION_DURATION_MI
 export NODE_ID="${NODE_ID:-node-0}"
 
 get_shared_dir() {
-  echo "${SCRIPT_DIR}/../${SHARED_DIR}"
+  echo "${COMMON_DIR}/../${SHARED_DIR}"
 }
 
 get_node_dir() {
-  local node_dir="${SCRIPT_DIR}/../${SHARED_DIR}/${NODE_ID}"
-  # Fallback for unported scripts: flat layout means pre-subdir deployment
-  if [[ ! -d "$node_dir" && -f "${SCRIPT_DIR}/../${SHARED_DIR}/aws-instance-id" ]]; then
-    echo "${SCRIPT_DIR}/../${SHARED_DIR}"
+  local node_dir="${COMMON_DIR}/../${SHARED_DIR}/${NODE_ID}"
+  if [[ ! -d "$node_dir" && -f "${COMMON_DIR}/../${SHARED_DIR}/aws-instance-id" ]]; then
+    echo "${COMMON_DIR}/../${SHARED_DIR}"
     return
   fi
   echo "$node_dir"

--- a/deploy/openshift-clusters/scripts/clean-spoke.sh
+++ b/deploy/openshift-clusters/scripts/clean-spoke.sh
@@ -6,17 +6,17 @@
 SCRIPT_DIR=$(dirname "$0")
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Source instance.env for SSH_PUBLIC_KEY and other settings
-# shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
+NODE_DIR="$(get_node_dir)"
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "${NODE_DIR}/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi
@@ -39,10 +39,8 @@ fi
 SPOKE_NETWORK="${SPOKE_CLUSTER_NAME}"
 
 # Get SSH connection info
-INSTANCE_IP=$(cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/public_address" 2>/dev/null \
-  || cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/public_address" 2>/dev/null || echo "")
-SSH_USER=$(cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/ssh_user" 2>/dev/null \
-  || cat "${DEPLOY_DIR}/aws-hypervisor/instance-data/ssh_user" 2>/dev/null || echo "ec2-user")
+INSTANCE_IP=$(cat "${NODE_DIR}/public_address" 2>/dev/null || echo "")
+SSH_USER=$(cat "${NODE_DIR}/ssh_user" 2>/dev/null || echo "ec2-user")
 
 if [[ -z "${INSTANCE_IP}" ]]; then
     echo "Error: Could not determine instance IP."

--- a/deploy/openshift-clusters/scripts/clean.sh
+++ b/deploy/openshift-clusters/scripts/clean.sh
@@ -5,13 +5,15 @@ SCRIPT_DIR=$(dirname "$0")
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "$(get_node_dir)/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi

--- a/deploy/openshift-clusters/scripts/deploy-cluster.sh
+++ b/deploy/openshift-clusters/scripts/deploy-cluster.sh
@@ -9,6 +9,9 @@ SCRIPT_DIR=$(dirname "$0")
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
@@ -68,8 +71,7 @@ if [[ "${METHOD}" != "ipi" && "${METHOD}" != "agent" && "${METHOD}" != "kcli" ]]
 fi
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "$(get_node_dir)/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi

--- a/deploy/openshift-clusters/scripts/deploy-fencing-assisted.sh
+++ b/deploy/openshift-clusters/scripts/deploy-fencing-assisted.sh
@@ -5,13 +5,15 @@ SCRIPT_DIR=$(dirname "$0")
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "$(get_node_dir)/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi

--- a/deploy/openshift-clusters/scripts/full-clean.sh
+++ b/deploy/openshift-clusters/scripts/full-clean.sh
@@ -5,13 +5,15 @@ SCRIPT_DIR=$(dirname "$0")
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "$(get_node_dir)/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi

--- a/deploy/openshift-clusters/scripts/patch-nodes.sh
+++ b/deploy/openshift-clusters/scripts/patch-nodes.sh
@@ -5,13 +5,15 @@ SCRIPT_DIR=$(dirname "$0")
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=/dev/null
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
+
 set -o nounset
 set -o errexit
 set -o pipefail
 
 # Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/node-0/aws-instance-id" ]] \
-&& [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+if [[ ! -f "$(get_node_dir)/aws-instance-id" ]]; then
     echo "Error: No instance found. Please run 'make deploy' first."
     exit 1
 fi

--- a/deploy/openshift-clusters/scripts/redeploy-cluster.sh
+++ b/deploy/openshift-clusters/scripts/redeploy-cluster.sh
@@ -4,29 +4,20 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
 # shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
-
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Resolve per-node directory (multi-node layout) with fallback for legacy deployments
-NODE_DIR="${SHARED_DIR}/node-0"
-if [[ ! -d "${NODE_DIR}" ]]; then
-    NODE_DIR="${SHARED_DIR}"
-fi
+NODE_DIR="$(get_node_dir)"
 
 # Function: Check if VM infrastructure needs to change and determine cleanup strategy
 check_vm_infrastructure_change() {
     local topology="$1"
-    local state_file="${SHARED_DIR}/cluster-vm-state.json"
+    local state_file
+    state_file="$(get_shared_dir)/cluster-vm-state.json"
     local current_topology="$topology"
     local previous_topology=""
     local previous_installation_method=""

--- a/deploy/openshift-clusters/scripts/shutdown-cluster.sh
+++ b/deploy/openshift-clusters/scripts/shutdown-cluster.sh
@@ -4,24 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
 # shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
-
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Resolve per-node directory (multi-node layout) with fallback for legacy deployments
-NODE_DIR="${SHARED_DIR}/node-0"
-if [[ ! -d "${NODE_DIR}" ]]; then
-    NODE_DIR="${SHARED_DIR}"
-fi
+NODE_DIR="$(get_node_dir)"
 
 # Check if the instance exists and get its ID
 if [[ ! -f "${NODE_DIR}/aws-instance-id" ]]; then

--- a/deploy/openshift-clusters/scripts/startup-cluster.sh
+++ b/deploy/openshift-clusters/scripts/startup-cluster.sh
@@ -4,24 +4,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
 # shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
-
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+source "${DEPLOY_DIR}/aws-hypervisor/scripts/common.sh"
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Resolve per-node directory (multi-node layout) with fallback for legacy deployments
-NODE_DIR="${SHARED_DIR}/node-0"
-if [[ ! -d "${NODE_DIR}" ]]; then
-    NODE_DIR="${SHARED_DIR}"
-fi
+NODE_DIR="$(get_node_dir)"
 
 # Check if the instance exists and get its ID
 if [[ ! -f "${NODE_DIR}/aws-instance-id" ]]; then
@@ -33,7 +23,7 @@ INSTANCE_ID=$(cat "${NODE_DIR}/aws-instance-id")
 echo "Starting up OpenShift cluster VMs on instance ${INSTANCE_ID}..."
 
 # Check cluster topology from state file
-CLUSTER_STATE_FILE="${SHARED_DIR}/cluster-vm-state.json"
+CLUSTER_STATE_FILE="$(get_shared_dir)/cluster-vm-state.json"
 CLUSTER_TOPOLOGY=""
 if [[ -f "${CLUSTER_STATE_FILE}" ]]; then
     CLUSTER_TOPOLOGY=$(grep -o '"topology":[[:space:]]*"[^"]*"' "${CLUSTER_STATE_FILE}" | cut -d'"' -f4 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Add `COMMON_DIR` (via `BASH_SOURCE[0]`) to `common.sh` so it resolves paths correctly when sourced from scripts outside `aws-hypervisor/scripts/`
- Port all 9 openshift-clusters scripts to source `common.sh` and use `get_node_dir()` / `get_shared_dir()` instead of duplicating inline path-fallback logic
- Net result: -21 lines, one place to maintain the node-dir resolution + legacy fallback

Follows up on PR #72 which added interim inline fallbacks to fix breakage.

## Test plan

- [x] `make shellcheck` passes
- [x] `make create` — instance provisions, `instance-data/node-0/` layout correct
- [x] `make deploy fencing-ipi` or `make deploy arbiter-ipi` — cluster deploys
- [x] `make shutdown-cluster` / `make startup-cluster` — lifecycle scripts read correct paths
- [x] `make redeploy-cluster` — reads cluster-vm-state.json from shared dir
- [x] `make clean` / `make full-clean` — existence check works
- [x] `make destroy` — ordered teardown succeeds
- [x] Verify legacy fallback: on a pre-subdir deployment (flat `instance-data/`), scripts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated deployment infrastructure scripts to reduce code duplication and improve consistency in path resolution across cluster management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->