### PR TITLE
Fix incorrect cluster ID behavior in force-new-cluster documentation

### DIFF
--- a/.claude/commands/etcd/QUICK_REFERENCE.md
+++ b/.claude/commands/etcd/QUICK_REFERENCE.md
@@ -105,21 +105,24 @@ ansible cluster_vms -i deploy/openshift-clusters/inventory.ini -m shell -a \
 
 **Symptoms:**
 - `pcs status` shows: `etcd monitor returned 'error' (master-X must force a new cluster)`
-- Both nodes have etcd running but with different cluster IDs
-- CIB attributes show different `cluster_id` values
+- Both nodes have etcd running as independent single-member clusters
+- Both nodes report `standalone_node` for themselves in CIB
+- Note: `cluster_id` may still match — `force-new-cluster` preserves it
 
 **Root Cause:**
 Network partition or simultaneous failures caused both nodes to start independent etcd clusters.
 
 **Diagnosis:**
 ```bash
-# Check cluster IDs on both nodes
+# Check for split-brain via standalone_node (reliable — both nodes claiming
+# standalone for themselves confirms split-brain, even if cluster_id matches)
 ansible cluster_vms -i deploy/openshift-clusters/inventory.ini -m shell -a \
-  "sudo crm_attribute -G -n cluster_id" -b
+  "sudo crm_attribute --query --name standalone_node" -b
 
-# Check which node is standalone
+# Supplementary: check cluster IDs (catches snapshot-restore divergence
+# but NOT force-new-cluster splits, since force-new-cluster preserves the ID)
 ansible cluster_vms -i deploy/openshift-clusters/inventory.ini -m shell -a \
-  "sudo crm_attribute -G -n standalone_node" -b
+  "sudo crm_attribute --type nodes --query --name cluster_id" -b
 
 # Alternative: Query etcd directly for member state
 ansible cluster_vms -i deploy/openshift-clusters/inventory.ini -m shell -a \

--- a/.claude/commands/etcd/TROUBLESHOOTING_SKILL.md
+++ b/.claude/commands/etcd/TROUBLESHOOTING_SKILL.md
@@ -266,7 +266,7 @@ Based on your analysis, provide:
 **Key Indicators:**
 - standalone_node: which node (if any) is running alone
 - learner_node: which node (if any) is rejoining
-- force_new_cluster: which node should bootstrap new cluster
+- force_new_cluster: which node should rewrite etcd membership (cluster ID preserved)
 - cluster_id: must match between nodes in healthy state
 - member_id: etcd member ID for each node
 
@@ -476,7 +476,7 @@ sudo journalctl -u pacemaker --grep fence --since "1 hour ago"
 ### Cluster States
 - **Standalone**: Single node running as "cluster-of-one"
 - **Learner**: Node rejoining cluster, not yet voting member
-- **Force-new-cluster**: Flag to bootstrap new cluster from single node
+- **Force-new-cluster**: Flag to rewrite etcd membership as single node (cluster ID preserved)
 
 ### Critical Attributes
 - `standalone_node` - Which node is running standalone
@@ -551,13 +551,13 @@ ansible-playbook helpers/force-new-cluster.yml -i deploy/openshift-clusters/inve
 - Etcd is not running on either node and won't start
 - After ungraceful disruptions that left cluster in inconsistent state
 - Manual recovery attempts have failed
-- Need to bootstrap from one node as new cluster
+- Need to rewrite etcd membership from one node (cluster ID preserved)
 
 **Precautions:**
 - Only use when normal recovery procedures fail
 - Ensure follower node can afford to lose its etcd data
 - Detected leader will become the source of truth
-- This creates a NEW cluster, follower will resync from leader
+- This rewrites etcd membership (cluster ID preserved), follower will resync from leader
 
 ## Reference Documentation
 

--- a/.claude/commands/etcd/TROUBLESHOOTING_SKILL.md
+++ b/.claude/commands/etcd/TROUBLESHOOTING_SKILL.md
@@ -494,8 +494,9 @@ sudo journalctl -u pacemaker --grep fence --since "1 hour ago"
 
 **Ungraceful Disruption** (4.20+):
 - Unreachable node is fenced (powered off)
-- Surviving node restarts etcd as cluster-of-one
-- New cluster ID is assigned
+- Surviving node restarts etcd with --force-new-cluster
+- Cluster ID is preserved (force-new-cluster reuses existing data, does not
+  generate a new ID)
 - Failed node discards old DB and resyncs on restart
 
 ## Available Remediation Tools


### PR DESCRIPTION
## Summary

- Fix documentation that claims `--force-new-cluster` assigns a new cluster ID — it preserves the existing one
- Update split-brain detection guidance from cluster ID comparison to CIB `standalone_node` attribute check

## Problem

The TROUBLESHOOTING_SKILL.md states under "Ungraceful Disruption (4.20+)":

> Surviving node restarts etcd as cluster-of-one. **New cluster ID is assigned.**

This is incorrect. `etcd --force-new-cluster` preserves the cluster ID from the
existing data directory. It rewrites cluster membership but does not generate a
new cluster ID.

The QUICK_REFERENCE.md recommends detecting split-brain by comparing `cluster_id`
CIB attributes. This check is insufficient because both nodes will show the same
cluster ID even when running as independent single-member clusters after
force-new-cluster.

## Evidence

Validated on HPE ProLiant e920t bare metal (2026-05-28) in openshift-eng/edge-tooling:

1. **Three force-new-cluster operations** — cluster ID unchanged every time
2. **Deliberate split-brain test** — both nodes ran force-new-cluster
   independently with fencing disabled. Cluster IDs remained identical on both
   sides despite running as independent single-member clusters
3. **podman-etcd source** — `attribute_node_cluster_id()` reads cluster ID from
   etcd via `revision.json`, never generates one
4. **etcd upstream issues** — etcd-io/etcd#2328 documents that
   `--force-new-cluster` retains stale peer membership metadata;
   etcd-io/etcd#8169 reports cluster ID mismatches when peer URLs change
   during recovery. Our tests confirm the ID is unchanged.

The reliable split-brain signal is both nodes reporting `standalone_node` for
themselves in CIB attributes.

## What is NOT changed

The `helpers/force-new-cluster.yml` playbook is correct and does not use
cluster ID for any decisions. It detects the leader via `etcdctl endpoint
status` (member_id == leader_id). No changes needed.

## Test plan

- [ ] Verify TROUBLESHOOTING_SKILL.md changes are accurate
- [ ] Verify QUICK_REFERENCE.md detection commands work on a TNF cluster
- [ ] Confirm force-new-cluster.yml playbook is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised etcd split‑brain troubleshooting to emphasize detecting split‑brain via Pacemaker node attributes and checking cluster ID divergence.
  * Clarified that force-new-cluster preserves existing cluster IDs and how that affects recovery behavior.
  * Updated example recovery steps and guidance to reflect the revised diagnostics and force-new-cluster semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->