### PR TITLE
fix: support Graviton (aarch64) bare metal instance types

### DIFF
--- a/deploy/aws-hypervisor/README.md
+++ b/deploy/aws-hypervisor/README.md
@@ -116,6 +116,40 @@ If you have configured the RHSM activation key variables in your `instance.env` 
 [ec2-user@ip-x-x-x-x ~]$ ./configure.sh
 ```
 
+## Graviton (aarch64) Instances
+
+This toolbox supports AWS Graviton bare metal instances (`c7g.metal`, `m7g.metal`, `r7g.metal`) as hypervisors. Graviton instances are ~40% cheaper than equivalent x86_64 instances (e.g., `c7g.metal` at $2.32/hr vs `c5n.metal` at $3.89/hr).
+
+### Configuration
+
+In your `instance.env`, set:
+
+```bash
+export RHEL_HOST_ARCHITECTURE=aarch64
+export EC2_INSTANCE_TYPE="c7g.metal"  # or m7g.metal, r7g.metal
+```
+
+AMI auto-detection works for both architectures — the `aarch64` → `arm64` mapping is handled automatically.
+
+### Metal3 Image Overrides
+
+Upstream Metal3 images (`quay.io/metal3-io/{ironic,vbmc,sushy-tools}`) are x86_64-only. On aarch64 hypervisors, you must override them with arm64 builds in your dev-scripts config (e.g., `config_fencing.sh`):
+
+```bash
+if [ "$(uname -m)" = "aarch64" ]; then
+    export IRONIC_IMAGE=quay.io/rh-edge-enablement/ironic:2026-06
+    export VBMC_IMAGE=quay.io/rh-edge-enablement/vbmc:2026-06
+    export SUSHY_TOOLS_IMAGE=quay.io/rh-edge-enablement/sushy-tools:2026-06
+fi
+```
+
+See `config_fencing_example.sh` for a complete example. To rebuild these images, use `helpers/build-metal3-arm64.sh` (see [helpers/README.md](../../helpers/README.md)).
+
+### Known Limitations
+
+- **IPv6 IPI is not supported on aarch64** — nodes enter `inspecting` but never PXE-boot the IPA ramdisk. Use `IP_STACK=v4`.
+- **CI release auto-discovery does not work** — you must set `OPENSHIFT_RELEASE_IMAGE` explicitly to an aarch64 payload (e.g., `quay.io/openshift-release-dev/ocp-release:4.22.0-aarch64`).
+
 ## Script Dependencies
 
 All scripts expect:

--- a/deploy/aws-hypervisor/instance.env.template
+++ b/deploy/aws-hypervisor/instance.env.template
@@ -5,9 +5,9 @@ export SHARED_DIR="instance-data"
 
 export AWS_PROFILE=microshift-dev
 export STACK_NAME=${USER}-dev
-export RHEL_HOST_ARCHITECTURE=x86_64
+export RHEL_HOST_ARCHITECTURE=x86_64  # Use "aarch64" for Graviton instances
 export REGION=us-west-2
-export EC2_INSTANCE_TYPE="c5n.metal"
+export EC2_INSTANCE_TYPE="c5n.metal"  # Graviton bare metal: c7g.metal, m7g.metal, r7g.metal
 export AWS_DEFAULT_REGION=us-west-2
 
 # EC2 Capacity Reservation Settings
@@ -20,7 +20,7 @@ export ENABLE_CAPACITY_RESERVATION=true
 
 export SSH_PUBLIC_KEY=/home/${USER}/.ssh/id_ed25519.pub #It is suggested that this key has no passphrase for ease of use
 
-# Leave empty for auto-detect ami for images, defaults to RHEL 9.6 GA
+# Leave empty to auto-detect the latest RHEL AMI for RHEL_HOST_ARCHITECTURE
 export RHEL_HOST_AMI=''
 export RHEL_VERSION=''
 

--- a/deploy/aws-hypervisor/scripts/common.sh
+++ b/deploy/aws-hypervisor/scripts/common.sh
@@ -57,11 +57,21 @@ function msg_info() {
   echo -e "${COLOR_BLUE}INFO: ${1}${COLOR_CLEAR}" >&2
 }
 
+function get_ami_arch() {
+  local arch="${RHEL_HOST_ARCHITECTURE}"
+  if [[ "${arch}" == "aarch64" ]]; then
+    arch="arm64"
+  fi
+  echo "${arch}"
+}
+
 function aws_ec2_describe_images() {
+  local ami_arch
+  ami_arch="$(get_ami_arch)"
   # shellcheck disable=SC2153 # REGION is an env var from instance.env, not a misspelling of local 'region'
   aws ec2 describe-images \
   --query 'reverse(sort_by(Images, &CreationDate))[].[Name, ImageId, CreationDate]' \
-  --filters "Name=name,Values=RHEL-${RHEL_VERSION}.*GA*${RHEL_HOST_ARCHITECTURE}*" \
+  --filters "Name=name,Values=RHEL-${RHEL_VERSION}*${ami_arch}*" \
   --region "${REGION}" \
   --owners amazon \
   --output json \

--- a/deploy/aws-hypervisor/scripts/create.sh
+++ b/deploy/aws-hypervisor/scripts/create.sh
@@ -91,7 +91,7 @@ else
 fi
 
 ec2Type="VirtualMachine"
-if [[ "$EC2_INSTANCE_TYPE" =~ c[0-9]+[a-z]*.metal ]]; then
+if [[ "$EC2_INSTANCE_TYPE" =~ \.metal$ ]]; then
   ec2Type="MetalMachine"
 fi
 

--- a/deploy/openshift-clusters/roles/dev-scripts/install-dev/files/config_fencing_example.sh
+++ b/deploy/openshift-clusters/roles/dev-scripts/install-dev/files/config_fencing_example.sh
@@ -28,3 +28,11 @@ export OPENSHIFT_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.21.0-
 
 # Disable sigstore image verification during installation
 export OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true
+
+# aarch64 (Graviton) Metal3 image overrides — upstream images are x86_64-only.
+# Rebuild monthly with: helpers/build-metal3-arm64.sh
+# if [ "$(uname -m)" = "aarch64" ]; then
+#     export IRONIC_IMAGE=quay.io/rh-edge-enablement/ironic:2026-06
+#     export VBMC_IMAGE=quay.io/rh-edge-enablement/vbmc:2026-06
+#     export SUSHY_TOOLS_IMAGE=quay.io/rh-edge-enablement/sushy-tools:2026-06
+# fi

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -8,6 +8,7 @@ This directory contains multiple helper tools for various OpenShift cluster oper
 
 - **Resource Agent Patching**: Scripts and playbooks (recommended usage) for installing RPM packages on cluster nodes using rpm-ostree's override functionality
 - **Fencing Validation**: Tools for validating two-node cluster fencing configuration and health
+- **arm64 Metal3 Image Builder**: Builds arm64 variants of Metal3 images for aarch64 hypervisors (Graviton)
 - **Custom OCP 5.x payload (optional)**: `resource-agents-build/custom-payload.sh` to build a custom RHCOS layer from the resource-agents RPM and publish a custom release image with `oc adm release new`
 
 ## Requirements
@@ -127,6 +128,46 @@ ansible all -i deploy/openshift-clusters/inventory.ini -m shell -a "./fencing_va
 
 **Note:** Disruptive testing functionality is not yet fully supported and should not be used in production environments.
 
+
+### arm64 Metal3 Image Builder
+
+Builds arm64 variants of Metal3 container images (ironic, vbmc, sushy-tools) from the upstream `metal3-io/ironic-image` source. Required because upstream only publishes x86_64 images to `quay.io/metal3-io/`.
+
+**Usage:**
+
+```bash
+# Build all images and push to quay.io/rh-edge-enablement
+./build-metal3-arm64.sh
+
+# Build from a release tag with a date-based tag
+./build-metal3-arm64.sh --ref v28.0.0 --tag 2026-06
+
+# Build only sushy-tools, don't push
+./build-metal3-arm64.sh --images sushy-tools --no-push
+
+# Use a different registry namespace
+./build-metal3-arm64.sh --namespace my-namespace
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--namespace <ns>` | Registry namespace (default: `rh-edge-enablement`) |
+| `--registry <reg>` | Container registry (default: `quay.io`) |
+| `--ref <git-ref>` | ironic-image git ref to build from (default: `main`) |
+| `--tag <tag>` | Image tag (default: `latest`) |
+| `--images <list>` | Comma-separated images to build (default: `ironic,vbmc,sushy-tools`) |
+| `--no-push` | Build only, do not push |
+| `--keep-source` | Do not remove cloned source after build |
+| `--source-dir <dir>` | Use existing ironic-image checkout |
+
+**Prerequisites:**
+- `podman` (with `qemu-user-static` if cross-building from x86_64)
+- Authenticated to the target registry (`podman login quay.io`)
+- Git
+
+**Rebuild cadence:** Monthly, or when upstream ironic-image changes. ~20 min native on aarch64, ~45 min cross-build from x86_64.
 
 ### Resource Agents Patching
 


### PR DESCRIPTION
## Summary

- Broaden metal-detection regex from `c[0-9]+[a-z]*.metal` (c-family only) to `\.metal$`, covering all bare metal instance types including Graviton (`c7g.metal`, `m7g.metal`, `r7g.metal`)
- Fix AMI auto-detect for aarch64: add `get_ami_arch()` to map `aarch64` → `arm64` (AWS uses `arm64` in AMI names), and remove `*GA*` filter that excluded all arm64 AMIs (and limited x86_64 to an older GA build)
- Add Graviton instance type hints to `instance.env.template`
- Add Graviton usage documentation to `deploy/aws-hypervisor/README.md` (configuration, Metal3 image overrides, known limitations)
- Document `build-metal3-arm64.sh` in `helpers/README.md`

Depends on #73 (branched from `openshift-clusters-common-sh`).

## Test plan

- [x] `make shellcheck` passes
- [x] AMI auto-detect returns correct AMI for `RHEL_HOST_ARCHITECTURE=x86_64`
- [x] AMI auto-detect returns correct AMI for `RHEL_HOST_ARCHITECTURE=aarch64`
- [x] Metal regex matches `c5n.metal`, `c7g.metal`, `m7g.metal`, `r7g.metal`, `i3.metal`
- [x] Metal regex rejects `c5n.xlarge`, `m5.2xlarge`
- [x] `make create` + `make destroy` on a Graviton instance type (e.g. `c7g.metal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved AMI auto-detection to normalize aarch64/Graviton architecture for more accurate image selection.
  * Enhanced detection of Graviton/bare-metal instance types by recognizing additional `.metal` naming patterns.

* **Documentation**
  * Updated deployment guidance for aarch64/Graviton, including clarified defaults for AMI auto-detection.
  * Added/expanded “Metal3 Image Overrides” documentation for arm64/aarch64 image rebuilds and example environment variables.
  * Documented an arm64 Metal3 image builder tool and its usage/options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->