### PR TITLE
Add bare metal agent-based install support

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -81,6 +81,18 @@ patch-nodes:
 get-tnf-logs:
 	@./openshift-clusters/scripts/get-tnf-logs.sh
 
+bm-init:
+	@./openshift-clusters/scripts/bm-init.sh
+
+bm-fencing-agent:
+	@./openshift-clusters/scripts/deploy-cluster.sh --topology fencing --method agent
+
+bm-arbiter-agent:
+	@./openshift-clusters/scripts/deploy-cluster.sh --topology arbiter --method agent
+
+bm-ssh:
+	@./openshift-clusters/scripts/bm-ssh.sh
+
 help:
 	@echo "Available commands:"
 	@echo ""
@@ -118,4 +130,10 @@ help:
 	@echo ""
 	@echo "Cluster Utilities:"
 	@echo "  get-tnf-logs         - Collect pacemaker and etcd logs from cluster nodes"
+	@echo ""
+	@echo "Bare Metal Deployment:"
+	@echo "  bm-init              - Initialize a bare metal host for cluster deployment (interactive)"
+	@echo "  bm-fencing-agent     - Deploy fencing cluster on bare metal (agent-based install)"
+	@echo "  bm-arbiter-agent     - Deploy arbiter cluster on bare metal (agent-based install)"
+	@echo "  bm-ssh               - SSH into the bare metal host"
 

--- a/deploy/openshift-clusters/scripts/bm-init.sh
+++ b/deploy/openshift-clusters/scripts/bm-init.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Initialize a bare metal host for two-node cluster deployment.
+# Usage: bm-init.sh [user@host]
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+INSTANCE_DATA_DIR="${DEPLOY_DIR}/aws-hypervisor/instance-data"
+INVENTORY_FILE="${DEPLOY_DIR}/openshift-clusters/inventory.ini"
+
+HOST_TARGET="${1:-}"
+
+if [[ -z "${HOST_TARGET}" ]]; then
+    read -rp "Enter bare metal host (user@host or IP): " HOST_TARGET
+fi
+
+if [[ -z "${HOST_TARGET}" ]]; then
+    echo "Error: No host specified."
+    exit 1
+fi
+
+# If only an IP/hostname was given, default to root@
+if [[ "${HOST_TARGET}" != *@* ]]; then
+    HOST_TARGET="root@${HOST_TARGET}"
+fi
+
+echo "Initializing bare metal host: ${HOST_TARGET}"
+
+# Generate inventory file
+echo "Generating inventory.ini..."
+cat > "${INVENTORY_FILE}" <<EOF
+[metal_machine]
+${HOST_TARGET} ansible_ssh_extra_args='-o ServerAliveInterval=30 -o ServerAliveCountMax=120'
+
+[metal_machine:vars]
+ansible_become_password=""
+EOF
+
+# Run the init-host playbook
+echo "Running init-host.yml playbook..."
+cd "${DEPLOY_DIR}/openshift-clusters"
+
+if ansible-playbook init-host.yml -i inventory.ini; then
+    echo ""
+    echo "Host initialization completed successfully!"
+
+    # Write the bare metal marker file
+    mkdir -p "${INSTANCE_DATA_DIR}"
+    echo "${HOST_TARGET}" > "${INSTANCE_DATA_DIR}/bare-metal-host"
+
+    echo ""
+    echo "Next steps:"
+    echo "  Deploy a cluster:"
+    echo "    make bm-fencing-agent"
+    echo "    make bm-arbiter-agent"
+else
+    echo "Error: Host initialization failed!"
+    echo "Check the Ansible logs for more details."
+    exit 1
+fi

--- a/deploy/openshift-clusters/scripts/bm-ssh.sh
+++ b/deploy/openshift-clusters/scripts/bm-ssh.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# SSH to a bare metal host initialized with bm-init.sh
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+MARKER_FILE="${DEPLOY_DIR}/aws-hypervisor/instance-data/bare-metal-host"
+
+if [[ ! -f "${MARKER_FILE}" ]]; then
+    echo "Error: No bare metal host found. Run 'make bm-init' first."
+    exit 1
+fi
+
+HOST_TARGET=$(cat "${MARKER_FILE}")
+echo "Connecting to bare metal host: ${HOST_TARGET}"
+ssh "${HOST_TARGET}"

--- a/deploy/openshift-clusters/scripts/clean.sh
+++ b/deploy/openshift-clusters/scripts/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get the directory where this script is located
-SCRIPT_DIR=$(dirname "$0")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -9,9 +9,12 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Check if instance data exists (EC2 or bare metal)
+if ! check_instance "${DEPLOY_DIR}" >/dev/null; then
     exit 1
 fi
 

--- a/deploy/openshift-clusters/scripts/common.sh
+++ b/deploy/openshift-clusters/scripts/common.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Shared helper functions for cluster management scripts.
+# Supports both AWS EC2 and bare metal deployments.
+#
+
+# Detect the instance type (aws or baremetal) by checking for marker files.
+# Prints the type to stdout and returns 0, or prints an error and returns 1.
+check_instance() {
+    local deploy_dir="$1"
+
+    if [[ -f "${deploy_dir}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
+        echo "aws"
+        return 0
+    elif [[ -f "${deploy_dir}/aws-hypervisor/instance-data/bare-metal-host" ]]; then
+        echo "baremetal"
+        return 0
+    fi
+
+    echo "Error: No instance found. Run 'make deploy' (EC2) or 'make bm-init' (bare metal) first." >&2
+    return 1
+}
+
+# Get a display identifier for the current instance (instance ID or hostname).
+get_instance_display() {
+    local deploy_dir="$1"
+    local instance_type="$2"
+
+    case "${instance_type}" in
+        aws)
+            cat "${deploy_dir}/aws-hypervisor/instance-data/aws-instance-id"
+            ;;
+        baremetal)
+            cat "${deploy_dir}/aws-hypervisor/instance-data/bare-metal-host"
+            ;;
+    esac
+}
+
+# Get the SSH user and host for connecting to the hypervisor.
+get_ssh_target() {
+    local deploy_dir="$1"
+    local instance_type="$2"
+
+    case "${instance_type}" in
+        aws)
+            local ssh_user host_ip
+            ssh_user=$(cat "${deploy_dir}/aws-hypervisor/instance-data/ssh_user")
+            host_ip=$(cat "${deploy_dir}/aws-hypervisor/instance-data/public_address")
+            echo "${ssh_user}@${host_ip}"
+            ;;
+        baremetal)
+            # Read the first metal_machine host from the inventory
+            grep -A1 '^\[metal_machine\]' "${deploy_dir}/openshift-clusters/inventory.ini" \
+                | tail -1 | awk '{print $1}'
+            ;;
+    esac
+}

--- a/deploy/openshift-clusters/scripts/deploy-cluster.sh
+++ b/deploy/openshift-clusters/scripts/deploy-cluster.sh
@@ -67,9 +67,12 @@ if [[ "${METHOD}" != "ipi" && "${METHOD}" != "agent" && "${METHOD}" != "kcli" ]]
     exit 1
 fi
 
-# Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Check if instance data exists (EC2 or bare metal)
+if ! check_instance "${DEPLOY_DIR}" >/dev/null; then
     exit 1
 fi
 

--- a/deploy/openshift-clusters/scripts/full-clean.sh
+++ b/deploy/openshift-clusters/scripts/full-clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get the directory where this script is located
-SCRIPT_DIR=$(dirname "$0")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -9,9 +9,12 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Check if instance data exists (EC2 or bare metal)
+if ! check_instance "${DEPLOY_DIR}" >/dev/null; then
     exit 1
 fi
 

--- a/deploy/openshift-clusters/scripts/patch-nodes.sh
+++ b/deploy/openshift-clusters/scripts/patch-nodes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get the directory where this script is located
-SCRIPT_DIR=$(dirname "$0")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the deploy directory (two levels up from scripts)
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -9,9 +9,12 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if instance data exists
-if [[ ! -f "${DEPLOY_DIR}/aws-hypervisor/instance-data/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# Check if instance data exists (EC2 or bare metal)
+if ! check_instance "${DEPLOY_DIR}" >/dev/null; then
     exit 1
 fi
 

--- a/deploy/openshift-clusters/scripts/redeploy-cluster.sh
+++ b/deploy/openshift-clusters/scripts/redeploy-cluster.sh
@@ -4,14 +4,12 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
-# shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+# Set SHARED_DIR (used by check_vm_infrastructure_change)
+export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/instance-data"
 
 set -o nounset
 set -o errexit
@@ -26,7 +24,7 @@ check_vm_infrastructure_change() {
     local previous_installation_method=""
     local previous_status=""
     
-    echo "Checking VM infrastructure requirements for instance ${INSTANCE_ID}..."
+    echo "Checking VM infrastructure requirements for ${INSTANCE_DISPLAY}..."
     
     # Read previous state if exists
     if [[ -f "$state_file" ]]; then
@@ -49,7 +47,7 @@ check_vm_infrastructure_change() {
         export current_installation_method="IPI"
     fi
 
-    echo "Instance: ${INSTANCE_ID}"
+    echo "Instance: ${INSTANCE_DISPLAY}"
     echo "Previous cluster config: ${previous_topology:-none}/${previous_installation_method:-none} (status: ${previous_status:-unknown})"
     echo "Current cluster config: ${current_topology}/${current_installation_method}"
     
@@ -104,37 +102,38 @@ check_vm_infrastructure_change() {
 
 # Note: Cluster state is now managed by the Ansible playbook
 
-# Check if the instance exists and get its ID
-if [[ ! -f "${SHARED_DIR}/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
-    exit 1
+# Detect instance type
+INSTANCE_TYPE=$(check_instance "${DEPLOY_DIR}") || exit 1
+INSTANCE_DISPLAY=$(get_instance_display "${DEPLOY_DIR}" "${INSTANCE_TYPE}")
+
+echo "Redeploying OpenShift cluster on ${INSTANCE_DISPLAY}..."
+
+if [[ "${INSTANCE_TYPE}" == "aws" ]]; then
+    # shellcheck source=/dev/null
+    source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
+
+    INSTANCE_ID="${INSTANCE_DISPLAY}"
+    INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
+
+    if [[ "${INSTANCE_STATE}" != "running" ]]; then
+        echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
+        echo "Cannot redeploy cluster on a stopped instance."
+        exit 1
+    fi
+
+    HOST_PUBLIC_IP=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --no-cli-pager)
+
+    if [[ "${HOST_PUBLIC_IP}" == "null" || "${HOST_PUBLIC_IP}" == "" ]]; then
+        echo "Error: Could not determine instance public IP"
+        exit 1
+    fi
+
+    echo "Connecting to instance at ${HOST_PUBLIC_IP}..."
+
+    # Update SSH config
+    echo "Updating SSH config for aws-hypervisor..."
+    (cd "${DEPLOY_DIR}/aws-hypervisor" && go run main.go -k aws-hypervisor -h "$HOST_PUBLIC_IP")
 fi
-
-INSTANCE_ID=$(cat "${SHARED_DIR}/aws-instance-id")
-echo "Redeploying OpenShift cluster on instance ${INSTANCE_ID}..."
-
-# Check current instance state
-INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
-
-if [[ "${INSTANCE_STATE}" != "running" ]]; then
-    echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
-    echo "Cannot redeploy cluster on a stopped instance."
-    exit 1
-fi
-
-# Get the instance IP
-HOST_PUBLIC_IP=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --no-cli-pager)
-
-if [[ "${HOST_PUBLIC_IP}" == "null" || "${HOST_PUBLIC_IP}" == "" ]]; then
-    echo "Error: Could not determine instance public IP"
-    exit 1
-fi
-
-echo "Connecting to instance at ${HOST_PUBLIC_IP}..."
-
-# Update SSH config
-echo "Updating SSH config for aws-hypervisor..."
-(cd "${DEPLOY_DIR}/aws-hypervisor" && go run main.go -k aws-hypervisor -h "$HOST_PUBLIC_IP")
 
 # Interactive mode selection
 echo ""

--- a/deploy/openshift-clusters/scripts/shutdown-cluster.sh
+++ b/deploy/openshift-clusters/scripts/shutdown-cluster.sh
@@ -4,50 +4,43 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
-# shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
-
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if the instance exists and get its ID
-if [[ ! -f "${SHARED_DIR}/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
-    exit 1
+# Detect instance type
+INSTANCE_TYPE=$(check_instance "${DEPLOY_DIR}") || exit 1
+INSTANCE_DISPLAY=$(get_instance_display "${DEPLOY_DIR}" "${INSTANCE_TYPE}")
+SSH_TARGET=$(get_ssh_target "${DEPLOY_DIR}" "${INSTANCE_TYPE}")
+
+echo "Shutting down OpenShift cluster VMs on ${INSTANCE_DISPLAY}..."
+
+if [[ "${INSTANCE_TYPE}" == "aws" ]]; then
+    # shellcheck source=/dev/null
+    source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
+    if [[ "${SHARED_DIR}" != /* ]]; then
+        export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
+    fi
+
+    INSTANCE_ID="${INSTANCE_DISPLAY}"
+    INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
+
+    if [[ "${INSTANCE_STATE}" != "running" ]]; then
+        echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
+        echo "Cannot shutdown cluster on a stopped instance."
+        exit 1
+    fi
 fi
 
-INSTANCE_ID=$(cat "${SHARED_DIR}/aws-instance-id")
-echo "Shutting down OpenShift cluster VMs on instance ${INSTANCE_ID}..."
-
-# Check current instance state
-INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
-
-if [[ "${INSTANCE_STATE}" != "running" ]]; then
-    echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
-    echo "Cannot shutdown cluster on a stopped instance."
-    exit 1
-fi
-
-# Get the instance IP
-HOST_PUBLIC_IP=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --no-cli-pager)
-
-if [[ "${HOST_PUBLIC_IP}" == "null" || "${HOST_PUBLIC_IP}" == "" ]]; then
-    echo "Error: Could not determine instance public IP"
-    exit 1
-fi
-
-echo "Connecting to instance at ${HOST_PUBLIC_IP}..."
+echo "Connecting to ${SSH_TARGET}..."
 
 # Check if dev-scripts directory exists
-set +e  # Allow commands to fail
-ssh -o ConnectTimeout=10 "$(cat "${SHARED_DIR}/ssh_user")@${HOST_PUBLIC_IP}" "test -d ~/openshift-metal3" 2>/dev/null
+set +e
+ssh -o ConnectTimeout=10 "${SSH_TARGET}" "test -d ~/openshift-metal3" 2>/dev/null
 DEV_SCRIPTS_EXISTS=$?
 set -e
 
@@ -74,7 +67,7 @@ else
 fi
 
 # Perform orderly shutdown of the cluster VMs
-ssh "$(cat "${SHARED_DIR}/ssh_user")@${HOST_PUBLIC_IP}" << 'EOF'
+ssh "${SSH_TARGET}" << 'EOF'
     set -e
     cd ~/openshift-metal3/dev-scripts
     

--- a/deploy/openshift-clusters/scripts/startup-cluster.sh
+++ b/deploy/openshift-clusters/scripts/startup-cluster.sh
@@ -4,27 +4,22 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 
-# Source the instance.env file with absolute path
-# shellcheck source=/dev/null
-source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
-
-# Resolve SHARED_DIR to absolute path if it's relative
-if [[ "${SHARED_DIR}" != /* ]]; then
-    export SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/${SHARED_DIR}"
-fi
+# Source shared helpers
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
 
 set -o nounset
 set -o errexit
 set -o pipefail
 
-# Check if the instance exists and get its ID
-if [[ ! -f "${SHARED_DIR}/aws-instance-id" ]]; then
-    echo "Error: No instance found. Please run 'make deploy' first."
-    exit 1
-fi
+# Detect instance type
+INSTANCE_TYPE=$(check_instance "${DEPLOY_DIR}") || exit 1
+INSTANCE_DISPLAY=$(get_instance_display "${DEPLOY_DIR}" "${INSTANCE_TYPE}")
+SSH_TARGET=$(get_ssh_target "${DEPLOY_DIR}" "${INSTANCE_TYPE}")
 
-INSTANCE_ID=$(cat "${SHARED_DIR}/aws-instance-id")
-echo "Starting up OpenShift cluster VMs on instance ${INSTANCE_ID}..."
+SHARED_DIR="${DEPLOY_DIR}/aws-hypervisor/instance-data"
+
+echo "Starting up OpenShift cluster VMs on ${INSTANCE_DISPLAY}..."
 
 # Check cluster topology from state file
 CLUSTER_STATE_FILE="${SHARED_DIR}/cluster-vm-state.json"
@@ -34,28 +29,25 @@ if [[ -f "${CLUSTER_STATE_FILE}" ]]; then
     echo "Detected cluster topology: ${CLUSTER_TOPOLOGY:-unknown}"
 fi
 
-# Check current instance state
-INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
+if [[ "${INSTANCE_TYPE}" == "aws" ]]; then
+    # shellcheck source=/dev/null
+    source "${DEPLOY_DIR}/aws-hypervisor/instance.env"
 
-if [[ "${INSTANCE_STATE}" != "running" ]]; then
-    echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
-    echo "Cannot start cluster on a stopped instance."
-    exit 1
+    INSTANCE_ID="${INSTANCE_DISPLAY}"
+    INSTANCE_STATE=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].State.Name' --output text --no-cli-pager)
+
+    if [[ "${INSTANCE_STATE}" != "running" ]]; then
+        echo "Error: Instance is not running (state: ${INSTANCE_STATE})"
+        echo "Cannot start cluster on a stopped instance."
+        exit 1
+    fi
 fi
 
-# Get the instance IP
-HOST_PUBLIC_IP=$(aws --region "${REGION}" ec2 describe-instances --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --no-cli-pager)
-
-if [[ "${HOST_PUBLIC_IP}" == "null" || "${HOST_PUBLIC_IP}" == "" ]]; then
-    echo "Error: Could not determine instance public IP"
-    exit 1
-fi
-
-echo "Connecting to instance at ${HOST_PUBLIC_IP}..."
+echo "Connecting to ${SSH_TARGET}..."
 
 # Check if dev-scripts directory exists
-set +e  # Allow commands to fail
-ssh -o ConnectTimeout=10 "$(cat "${SHARED_DIR}/ssh_user")@${HOST_PUBLIC_IP}" "test -d ~/openshift-metal3" 2>/dev/null
+set +e
+ssh -o ConnectTimeout=10 "${SSH_TARGET}" "test -d ~/openshift-metal3" 2>/dev/null
 DEV_SCRIPTS_EXISTS=$?
 set -e
 
@@ -68,7 +60,7 @@ fi
 echo "Found dev-scripts directory. Starting up OpenShift cluster VMs..."
 
 # Start the cluster VMs remotely
-ssh "$(cat "${SHARED_DIR}/ssh_user")@${HOST_PUBLIC_IP}" << 'EOF'
+ssh "${SSH_TARGET}" << 'EOF'
     set -e
     cd ~/openshift-metal3/dev-scripts
     
@@ -170,7 +162,7 @@ if [[ "${CLUSTER_TOPOLOGY}" == "fencing" ]]; then
     echo ""
     echo "Fencing topology detected. Ensuring sushy-tools BMC simulator is running..."
 
-    ssh "$(cat "${SHARED_DIR}/ssh_user")@${HOST_PUBLIC_IP}" << 'EOF'
+    ssh "${SSH_TARGET}" << 'EOF'
         # Check if sushy-tools container exists (dev-scripts deployment)
         if sudo podman container exists sushy-tools 2>/dev/null; then
             CONTAINER_STATUS=$(sudo podman inspect sushy-tools --format '{{.State.Status}}' 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary

- Add `bm-*` Makefile targets for deploying TNF/TNA clusters on bare metal hosts using agent-based install via dev-scripts
- Create shared `common.sh` helper that detects instance type (EC2 vs bare metal), enabling all management scripts to work on both
- Refactor 7 existing scripts to replace hardcoded `aws-instance-id` gate checks with the shared helper

## New targets

| Target | Description |
|--------|-------------|
| `bm-init` | Initialize a bare metal host (generates inventory, runs `init-host.yml`) |
| `bm-fencing-agent` | Deploy fencing cluster on bare metal (agent-based install) |
| `bm-arbiter-agent` | Deploy arbiter cluster on bare metal (agent-based install) |
| `bm-ssh` | SSH into the bare metal host |

Existing management commands (`clean`, `redeploy-cluster`, `shutdown-cluster`, `startup-cluster`, `patch-nodes`) now work for both EC2 and bare metal deployments.

## Test plan

- [ ] Verify `make help` shows the new Bare Metal Deployment section
- [ ] Run `shellcheck` on all new and modified scripts (passes at warning level)
- [ ] Test `bm-init` with a bare metal RHEL 9 host
- [ ] Test `bm-fencing-agent` or `bm-arbiter-agent` end-to-end
- [ ] Verify existing EC2 workflow is unbroken (`make deploy`, `fencing-ipi`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)