### PR TITLE
fix: restore ARP fallback in resolve_vm_ip.sh for static networking

### DIFF
--- a/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
+++ b/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
@@ -22,29 +22,36 @@ fi
 INTERFACES=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $3 != "" && $5 != "" {print $3, tolower($5)}')
 
 # --- Primary: ARP/neighbor table lookup (works for static and DHCP networking) ---
+# Collect candidates scored by preference, then validate with SSH reachability.
+# VIPs (API, ingress) share the NIC's MAC, so multiple IPs may match; the SSH
+# check ensures we return the actual node address.
 MACS=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $5 != "" {print tolower($5)}')
+CANDIDATES=""
 for MAC in $MACS; do
-  # Score candidates: prefer IPv4, then REACHABLE+router IPv6, then best available.
-  # On IPv6, multiple addresses share a MAC (node IP, VIPs); scoring avoids picking a VIP.
-  BEST=$(ip neigh | awk -v mac="$MAC" '
-    BEGIN { m = tolower(mac); best_score = -1 }
+  SCORED=$(ip neigh | awk -v mac="$MAC" '
+    BEGIN { m = tolower(mac) }
     tolower($5) != m { next }
     /^fe80:/ || /^fd00:/ { next }
     {
       score = 0
-      is_v4 = ($1 !~ /:/)
-      if (is_v4) score += 10
+      if ($1 !~ /:/) score += 10
       if (/router/) score += 2
       if ($NF == "REACHABLE") score += 1
-      if (score > best_score) { best_score = score; best_ip = $1 }
+      printf "%d %s\n", score, $1
     }
-    END { if (best_ip != "") print best_ip }
   ')
-  if [[ -n "$BEST" ]]; then
-    echo "$BEST"
-    exit 0
-  fi
+  [[ -n "$SCORED" ]] && CANDIDATES="${CANDIDATES}${CANDIDATES:+$'\n'}${SCORED}"
 done
+if [[ -n "$CANDIDATES" ]]; then
+  while IFS=' ' read -r _score ip; do
+    REMOTE_HOST=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      -o ConnectTimeout=2 -o BatchMode=yes "core@${ip}" "hostname -s" 2>/dev/null) || continue
+    if [[ -z "$EXPECTED_HOSTNAME" ]] || [[ "$REMOTE_HOST" == *"${EXPECTED_HOSTNAME}"* ]]; then
+      echo "$ip"
+      exit 0
+    fi
+  done <<< "$(echo "$CANDIDATES" | sort -rn)"
+fi
 
 # --- Fallback: DHCP lease lookup (hostname-aware, dual-stack safe) ---
 

--- a/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
+++ b/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Resolve VM IP from virsh net-dhcp-leases. The same MAC can appear twice (anonymous
-# DUID vs hostname); prefer the row whose Hostname matches this VM (e.g. master-0).
-# Dual-stack leases can list both ipv4 and ipv6 for one MAC; prefer ipv4, then ipv6.
+# Resolve VM IP by checking the host's ARP/neighbor table first (works for both
+# static and DHCP networking), then falling back to virsh DHCP leases.
+# Dual-stack: prefer IPv4, then global IPv6 (skip link-local fe80:: and ULA fd00::).
 set -euo pipefail
 
 VM_NAME="${1:?VM name required}"
@@ -20,6 +20,31 @@ elif [[ "$VM_NAME" =~ -(ctlplane|arbiter)-?([0-9]*)$ ]]; then
 fi
 
 INTERFACES=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $3 != "" && $5 != "" {print $3, tolower($5)}')
+
+# --- Primary: ARP/neighbor table lookup (works for static and DHCP networking) ---
+MACS=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $5 != "" {print tolower($5)}')
+for MAC in $MACS; do
+  IP=$(ip neigh | awk -v mac="$MAC" '
+    BEGIN { m = tolower(mac) }
+    tolower($5) != m { next }
+    /^fe80:/ || /^fd00:/ { next }
+    { print $1 }
+  ')
+  [[ -z "$IP" ]] && continue
+  # Prefer IPv4 over IPv6 when both exist
+  IPV4=$(echo "$IP" | grep -v ':' | head -n1)
+  if [[ -n "$IPV4" ]]; then
+    echo "$IPV4"
+    exit 0
+  fi
+  IPV6=$(echo "$IP" | head -n1)
+  if [[ -n "$IPV6" ]]; then
+    echo "$IPV6"
+    exit 0
+  fi
+done
+
+# --- Fallback: DHCP lease lookup (hostname-aware, dual-stack safe) ---
 
 lease_ip_for_mac() {
   local LEASES="$1"

--- a/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
+++ b/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
@@ -24,22 +24,24 @@ INTERFACES=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $3 != "
 # --- Primary: ARP/neighbor table lookup (works for static and DHCP networking) ---
 MACS=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $5 != "" {print tolower($5)}')
 for MAC in $MACS; do
-  IP=$(ip neigh | awk -v mac="$MAC" '
-    BEGIN { m = tolower(mac) }
+  # Score candidates: prefer IPv4, then REACHABLE+router IPv6, then best available.
+  # On IPv6, multiple addresses share a MAC (node IP, VIPs); scoring avoids picking a VIP.
+  BEST=$(ip neigh | awk -v mac="$MAC" '
+    BEGIN { m = tolower(mac); best_score = -1 }
     tolower($5) != m { next }
     /^fe80:/ || /^fd00:/ { next }
-    { print $1 }
+    {
+      score = 0
+      is_v4 = ($1 !~ /:/)
+      if (is_v4) score += 10
+      if (/router/) score += 2
+      if ($NF == "REACHABLE") score += 1
+      if (score > best_score) { best_score = score; best_ip = $1 }
+    }
+    END { if (best_ip != "") print best_ip }
   ')
-  [[ -z "$IP" ]] && continue
-  # Prefer IPv4 over IPv6 when both exist
-  IPV4=$(echo "$IP" | grep -v ':' | head -n1)
-  if [[ -n "$IPV4" ]]; then
-    echo "$IPV4"
-    exit 0
-  fi
-  IPV6=$(echo "$IP" | head -n1)
-  if [[ -n "$IPV6" ]]; then
-    echo "$IPV6"
+  if [[ -n "$BEST" ]]; then
+    echo "$BEST"
     exit 0
   fi
 done

--- a/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
+++ b/deploy/openshift-clusters/roles/common/files/resolve_vm_ip.sh
@@ -28,7 +28,7 @@ INTERFACES=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $3 != "
 MACS=$(virsh -c qemu:///system domiflist "$VM_NAME" | awk 'NR>2 && $5 != "" {print tolower($5)}')
 CANDIDATES=""
 for MAC in $MACS; do
-  SCORED=$(ip neigh | awk -v mac="$MAC" '
+  SCORED=$(ip neigh 2>/dev/null | awk -v mac="$MAC" '
     BEGIN { m = tolower(mac) }
     tolower($5) != m { next }
     /^fe80:/ || /^fd00:/ { next }

--- a/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
+++ b/deploy/openshift-clusters/roles/common/tasks/update-cluster-inventory.yml
@@ -17,7 +17,7 @@
 - name: Process cluster VMs
   when: has_cluster_vms | bool
   block:
-    - name: Get VM IP addresses from DHCP leases (hostname preferred)
+    - name: Get VM IP addresses (ARP neighbor table, DHCP lease fallback)
       script: "{{ role_path | default(playbook_dir + '/roles/common') }}/files/resolve_vm_ip.sh {{ item | quote }}"
       register: vm_ips
       loop: "{{ cluster_vms.stdout_lines }}"


### PR DESCRIPTION
## Summary

- `resolve_vm_ip.sh` was extracted from an inline Ansible task in `7f70935` but the `ip neigh` (ARP/neighbor table) lookup was dropped, leaving only DHCP lease resolution
- Agent-based installs with static networking (e.g. `TNA_IPV4`, `TNF_IPV4`) assign VMs IPs outside the DHCP range (`.80`+), so they never send DHCP requests and the lease table stays empty
- This caused "Inventory updated with 0 cluster VM(s)" after successful ABI deployments
- Restores `ip neigh` as the **primary** lookup method (works for both static and DHCP), keeping the DHCP hostname-aware lease logic as fallback
- Scores NDP/ARP candidates to handle VIP ambiguity (multiple addresses share a MAC)
- Validates candidates via SSH hostname check to reliably distinguish node IPs from VIPs

## Regression details

| Before `7f70935` (inline task) | After `7f70935` (extracted script) |
|---|---|
| 1. `ip neigh` (ARP table) | ~~removed~~ |
| 2. `virsh net-dhcp-leases` (fallback) | 1. `virsh net-dhcp-leases` (only method) |

IPI and `*_DHCP` agent scenarios were unaffected because VMs use DHCP and leases are populated. Static-networking agent scenarios (`TNA_IPV4`, `TNF_IPV4`, etc.) silently failed.

## IPv6 fixes (second commit)

On IPv6 IPI clusters, OCP nodes have multiple addresses on the same NIC (node IP, API VIP, ingress VIP) — all sharing the same MAC in the NDP table. Two bugs:

1. **`pipefail` + `grep -v ':'`**: On pure IPv6 stacks, `grep -v ':'` finds no matches (all IPs contain `:`), exits 1, and kills the script under `set -euo pipefail`
2. **VIP selection**: `ip neigh` returns NDP entries in arbitrary order, so the script could pick an unreachable VIP instead of the SSH-reachable node IP

Fix: replace the separate `grep` pipeline with awk-based scoring — prefer IPv4 (+10), `router` flag (+2), `REACHABLE` state (+1).

## VIP validation (third commit)

Scoring alone can't reliably distinguish node IPs from VIPs — on IPv4 there's no `router` flag, and VIPs respond on port 22 (sshd binds `0.0.0.0`). The fix validates each candidate by SSHing in and checking `hostname -s` against the expected node name. VIPs are floating (keepalived), so they return the hostname of whichever node currently holds them, correctly failing the match for the wrong node. Adds ~330ms per VM (vs ~80ms without validation).

## Test plan

- [x] Deploy arbiter-agent cluster with `TNA_IPV4` (static networking) — verify inventory populated with `.80`+ IPs
- [x] Deploy fencing-ipi cluster (DHCP networking) — verify no regression, inventory still works
- [x] Deploy arbiter-ipi cluster with `IP_STACK=v6` (IPv6, OCP 4.22.0-rc.5, c5n.metal x86_64) — verified:
  - `pipefail` bug: script crashed before fix, resolves correctly after
  - VIP scoring: `::14`/`::15`/`::16` (node IPs) selected over `::1d`/`::17`/`::5` (VIPs)
  - SSH connectivity confirmed to all 3 resolved addresses
- [x] Re-test IPv4 fencing-IPI (2m cluster, OCP 4.22, c5n.metal) — `.20`/`.21` correctly resolved over `.4`/`.5` VIPs via SSH hostname validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM IP resolution during cluster setup by prioritizing the host ARP/neighbor table (preferring IPv4, then global IPv6) with validation against the expected hostname, and falling back to DHCP leases—improves reliability and speed of IP discovery.
* **Documentation**
  * Updated in-script documentation to describe the new two-step, dual-stack resolution order and selection logic.
* **Chore**
  * Updated task labeling to reflect the new resolution approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->