### PR TITLE
Detect RHEL major version dynamically for repo configuration

### DIFF
--- a/deploy/aws-hypervisor/scripts/configure.sh
+++ b/deploy/aws-hypervisor/scripts/configure.sh
@@ -8,7 +8,13 @@ sudo hostnamectl set-hostname "aws-${STACK_NAME}"
 
 function get_ocp_version() {
     local latest_ga_ocp_version
-    local default_version="${DEFAULT_OCP_VERSION:-4.20}"
+    local default_version="${DEFAULT_OCP_VERSION:-}"
+    if [[ -z "${default_version}" ]]; then
+        case "${RHEL_MAJOR_VERSION}" in
+            10) default_version="4.23" ;;
+            *)  default_version="4.20" ;;
+        esac
+    fi
     if latest_ga_ocp_version="$(curl -sL https://sippy.dptools.openshift.org/api/releases | jq -re '.ga_dates | to_entries | max_by(.value) | .key')";
     then
         echo "${latest_ga_ocp_version:-$default_version}"

--- a/deploy/aws-hypervisor/scripts/configure.sh
+++ b/deploy/aws-hypervisor/scripts/configure.sh
@@ -2,6 +2,8 @@
 # shellcheck source=/dev/null
 source ~/profile.env
 
+RHEL_MAJOR_VERSION=$(. /etc/os-release && echo "${VERSION_ID%%.*}")
+
 sudo hostnamectl set-hostname "aws-${STACK_NAME}"
 
 function get_ocp_version() {
@@ -45,9 +47,9 @@ fi
 
 sudo subscription-manager attach --pool=8a85f99c7d76f2fd017d96c411c70667
 sudo subscription-manager repos \
---enable "rhel-9-for-$(uname -m)-appstream-rpms" \
---enable "rhel-9-for-$(uname -m)-baseos-rpms" \
---enable "rhocp-$(get_ocp_version)-for-rhel-9-$(uname -m)-rpms"
+--enable "rhel-${RHEL_MAJOR_VERSION}-for-$(uname -m)-appstream-rpms" \
+--enable "rhel-${RHEL_MAJOR_VERSION}-for-$(uname -m)-baseos-rpms" \
+--enable "rhocp-$(get_ocp_version)-for-rhel-${RHEL_MAJOR_VERSION}-$(uname -m)-rpms"
 
 # Enable CodeReady Builder (CRB) repo for -devel packages (e.g. libvirt-devel).
 # On RHUI instances (like AWS), subscription-manager repos --enable doesn't work
@@ -57,7 +59,7 @@ enable_crb_repo() {
     if command -v crb &>/dev/null; then
         sudo crb enable
     else
-        sudo subscription-manager repos --enable "codeready-builder-for-rhel-9-$(uname -m)-rpms"
+        sudo subscription-manager repos --enable "codeready-builder-for-rhel-${RHEL_MAJOR_VERSION}-$(uname -m)-rpms"
     fi
 }
 

--- a/deploy/openshift-clusters/init-host.yml
+++ b/deploy/openshift-clusters/init-host.yml
@@ -185,6 +185,11 @@
             - rhsm_activation_key is not defined or rhsm_activation_key | length == 0
       when: not rhsm_already_registered
 
+    - name: Override default OCP version for RHEL 10+
+      ansible.builtin.set_fact:
+        default_ocp_version: "4.23"
+      when: ansible_distribution_major_version | int >= 10
+
     - name: Get latest OCP version
       ansible.builtin.uri:
         url: https://sippy.dptools.openshift.org/api/releases

--- a/deploy/openshift-clusters/init-host.yml
+++ b/deploy/openshift-clusters/init-host.yml
@@ -212,9 +212,9 @@
     - name: Enable required repositories
       community.general.rhsm_repository:
         name:
-          - "rhel-9-for-{{ ansible_architecture }}-appstream-rpms"
-          - "rhel-9-for-{{ ansible_architecture }}-baseos-rpms"
-          - "rhocp-{{ ocp_version }}-for-rhel-9-{{ ansible_architecture }}-rpms"
+          - "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-appstream-rpms"
+          - "rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-baseos-rpms"
+          - "rhocp-{{ ocp_version }}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
         state: enabled
       become: yes
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded `rhel-9` in subscription-manager repo names with runtime detection of the RHEL major version
- `configure.sh` reads from `/etc/os-release`; `init-host.yml` uses the `ansible_distribution_major_version` fact
- Enables RHEL 10 as a hypervisor OS without breaking RHEL 9 deployments

## Background

OpenShift 5 moves to RHEL 10 as the base OS. The hypervisor hosts provisioned by tnt (and ofcir) need to support RHEL 10 AMIs. The AMI selection (`RHEL_VERSION` env var, `get_rhel_ami()`) already works for any version, but post-provision setup fails because repo names like `rhel-9-for-x86_64-baseos-rpms` don't exist on a RHEL 10 subscription.

## Test plan

- [x] `shellcheck` passes
- [x] `bash -n configure.sh` syntax check passes
- [x] Deployed RHEL 10.0 EC2 instance (`RHEL-10.0.0_HVM_GA-20250423-x86_64-0-Hourly2-GP3`)
- [x] Verified `make init` succeeds on RHEL 10 — all 4 repos enabled correctly:
  - `rhel-10-for-x86_64-appstream-rpms`
  - `rhel-10-for-x86_64-baseos-rpms`
  - `rhocp-4.22-for-rhel-10-x86_64-rpms`
  - `codeready-builder-for-rhel-10-x86_64-rpms`
- [x] Verified no regression on RHEL 9.6 — repos resolve identically to previous hardcoded values:
  - `rhel-9-for-x86_64-appstream-rpms`
  - `rhel-9-for-x86_64-baseos-rpms`
  - `rhocp-4.22-for-rhel-9-x86_64-rpms`
  - `codeready-builder-for-rhel-9-x86_64-rpms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RHEL 10 support with automatic version detection for deployment scripts.
  * System RHEL version now dynamically determines OpenShift and repository configurations instead of hardcoded defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->