### PR TITLE
Fix QEMU permission denied for agent-based installs

### DIFF
--- a/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/create.yml
+++ b/deploy/openshift-clusters/roles/dev-scripts/install-dev/tasks/create.yml
@@ -23,8 +23,8 @@
   become: true
   when: method == "agent"
   loop:
-    - "."
-    - "/root"
+    - "{{ ansible_env.HOME }}"
+    - "{{ ansible_env.HOME }}/{{ dev_scripts_path }}"
 
 - name: Start OpenShift
   make:


### PR DESCRIPTION
## Summary
- The ACL task in `create.yml` hardcoded `/root`, but dev-scripts is deployed under `/home/ec2-user`
- QEMU needs `rx` on the actual home directory to traverse the path to the agent ISO
- Replaced hardcoded `/root` with `{{ ansible_env.HOME }}` and `{{ dev_scripts_path }}`
- Only affects `agent` method installs (task has `when: method == "agent"`)
- IPI installs (`fencing-ipi`, `arbiter-ipi`) are unaffected — this task is skipped entirely

Fixes #85

## Test plan
- [ ] Deploy cluster with `method=agent` and verify QEMU starts VMs without permission errors
- [ ] Deploy cluster with `method=ipi` and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the file access permissions used during agent installation to grant the `qemu` user the required `rx` access to the correct home-based directories.
  * This improves reliability by ensuring permissions are applied to the environment-appropriate locations rather than fixed paths, helping avoid install failures caused by insufficient filesystem access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->