### PR TITLE
Rename ABI-specific baremetal vars to AGENT_BAREMETAL_* prefix

### DIFF
--- a/deploy/openshift-clusters/inventory_baremetal.ini.sample
+++ b/deploy/openshift-clusters/inventory_baremetal.ini.sample
@@ -16,7 +16,7 @@
 #   boot_mac   - (optional) MAC address of the NIC used for PXE boot
 #                If omitted, the adopt script attempts Redfish discovery.
 #   data_mac   - MAC address of the data NIC (for agent-config hostname mapping)
-#                May differ from boot_mac on multi-NIC servers. Emitted as BAREMETAL_MACS.
+#                May differ from boot_mac on multi-NIC servers. Emitted as AGENT_BAREMETAL_MACS.
 #   node_ip    - Static IP address for this node on the machine network
 #
 # The hostname (first field) becomes the node name in ironic_nodes.json.

--- a/deploy/openshift-clusters/scripts/baremetal-adopt.sh
+++ b/deploy/openshift-clusters/scripts/baremetal-adopt.sh
@@ -431,33 +431,33 @@ generate_baremetal_config() {
         echo "export MANAGE_INT_BRIDGE=n"
         echo "export AGENT_E2E_TEST_SCENARIO=\"TNF_IPV4_DHCP\""
 
-        # BAREMETAL_IPS is required — dev-scripts crashes under set -u without it
+        # AGENT_BAREMETAL_IPS is required — dev-scripts agent pipeline needs node IPs
         local ip_list=""
         for ((i = 0; i < ${#NODE_IPS[@]}; i++)); do
             [[ -z "${NODE_IPS[$i]}" ]] && die "Node '${NODE_NAMES[$i]}': node_ip is required for baremetal deploy"
             [[ -n "${ip_list}" ]] && ip_list+=","
             ip_list+="${NODE_IPS[$i]}"
         done
-        echo "export BAREMETAL_IPS=\"${ip_list}\""
+        echo "export AGENT_BAREMETAL_IPS=\"${ip_list}\""
 
-        # BAREMETAL_API_VIP is required — set_api_and_ingress_vip() needs it
+        # BAREMETAL_API_VIP is platform-level (used by both IPI and ABI in network.sh)
         [[ -z "${API_VIP}" ]] && die "api_vip is required in [baremetal_network] for baremetal deploy"
         [[ -z "${ISO_URL}" ]] && die "iso_url is required in [baremetal_network] for baremetal deploy"
         echo ""
         echo "# Baremetal network config"
         echo "export BAREMETAL_API_VIP=\"${API_VIP}\""
-        echo "export BAREMETAL_ISO_SERVER=\"${ISO_URL}\""
+        echo "export AGENT_BAREMETAL_ISO_SERVER=\"${ISO_URL}\""
         [[ -n "${MACHINE_NETWORK}" ]] && echo "export EXTERNAL_SUBNET_V4=\"${MACHINE_NETWORK}\""
         [[ -n "${INGRESS_VIP}" ]] && echo "export BAREMETAL_INGRESS_VIP=\"${INGRESS_VIP}\""
 
-        # BAREMETAL_MACS is required — agent-config needs data NIC MACs for hostname mapping
+        # AGENT_BAREMETAL_MACS is required — agent-config needs data NIC MACs for hostname mapping
         local mac_list=""
         for ((i = 0; i < ${#NODE_DATA_MACS[@]}; i++)); do
             [[ -z "${NODE_DATA_MACS[$i]}" ]] && die "Node '${NODE_NAMES[$i]}': data_mac is required for baremetal deploy"
             [[ -n "${mac_list}" ]] && mac_list+=","
             mac_list+="${NODE_DATA_MACS[$i]}"
         done
-        echo "export BAREMETAL_MACS=\"${mac_list}\""
+        echo "export AGENT_BAREMETAL_MACS=\"${mac_list}\""
     } > "${output_file}"
 
     info "  → ${output_file}"


### PR DESCRIPTION
## Summary

- Rename `BAREMETAL_IPS` → `AGENT_BAREMETAL_IPS`, `BAREMETAL_ISO_SERVER` → `AGENT_BAREMETAL_ISO_SERVER`, `BAREMETAL_MACS` → `AGENT_BAREMETAL_MACS` in `baremetal-adopt.sh`
- Keep `BAREMETAL_API_VIP` and `BAREMETAL_INGRESS_VIP` as-is (platform-level, used by both IPI and ABI in `network.sh`)

## Why

Aligns with [dev-scripts#1922](https://github.com/openshift-metal3/dev-scripts/pull/1922) naming convention. dtantsur's review requested that ABI-specific config vars use the `AGENT_` prefix to distinguish them from platform-level vars. The rename was applied in dev-scripts; this PR updates the generator side.

## Dependency chain

```
metal3-dev-env#1708  ─── upstream RHEL 10 fix (independent)
        │
        ▼
  This PR (TNT)  ──────── generates AGENT_BAREMETAL_* var names
        │
        ▼
dev-scripts#1922  ─────── consumes AGENT_BAREMETAL_* var names
```

**This PR must merge before dev-scripts#1922** — otherwise the generated config file uses old names that dev-scripts no longer reads.

/hold

## Test plan

- [x] `make shellcheck` passes
- [x] `make baremetal-adopt` generates `config_baremetal_fencing.sh` with `AGENT_BAREMETAL_*` var names
- [x] End-to-end baremetal deploy with updated dev-scripts branch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bare-metal deployment configuration exports to use agent-specific node addressing and ISO server settings.
  * Improved validation to ensure required node IP and data MAC values are present during configuration generation.
  * Preserved existing handling for API VIP, external subnet, ingress VIP, and ISO URL settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->