### PR TITLE
doctor.sh: add CI API token validation check

### DIFF
--- a/deploy/openshift-clusters/scripts/doctor.sh
+++ b/deploy/openshift-clusters/scripts/doctor.sh
@@ -323,8 +323,8 @@ for topology in arbiter fencing sno; do
     fi
   fi
 
-  # CI token live check: only when CI_TOKEN is set and the release image is on
-  # the CI registry (same condition as install-dev/tasks/config.yml)
+  # CI token registry check: only when CI_TOKEN is set and the release image
+  # is on the CI registry (same condition as install-dev/tasks/config.yml)
   CI_TOKEN="$(sed -nE 's/^export CI_TOKEN="([^"]+)".*/\1/p' "${CONFIG_FILE}" | head -1)"
   RELEASE_REGISTRY="$(sed -nE 's|^export OPENSHIFT_RELEASE_IMAGE="?([^/"]+).*|\1|p' "${CONFIG_FILE}" | head -1)"
   if [[ -n "${CI_TOKEN}" && "${RELEASE_REGISTRY}" == "registry.ci.openshift.org" ]]; then
@@ -343,6 +343,28 @@ for topology in arbiter fencing sno; do
         check_pass "CI token in config_${topology}.sh accepted by ${RELEASE_REGISTRY}"
       else
         check_warn "CI token check: unexpected HTTP ${HTTP_CODE} from ${RELEASE_REGISTRY}"
+      fi
+    fi
+  fi
+
+  if [[ -n "${CI_TOKEN}" ]]; then
+    CI_SERVER="api.ci.l2s4.p1.openshiftapps.com"
+    if ! command -v curl >/dev/null 2>&1; then
+      check_warn "CI API token check skipped: 'curl' not found on PATH"
+    else
+      HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+        -H "Authorization: Bearer ${CI_TOKEN}" \
+        "https://${CI_SERVER}:6443/apis/user.openshift.io/v1/users/~")"
+      CURL_RC=$?
+      if [[ ${CURL_RC} -ne 0 ]]; then
+        check_warn "CI API token check: curl failed (exit ${CURL_RC}) reaching ${CI_SERVER}"
+      elif [[ "${HTTP_CODE}" == "401" ]]; then
+        check_fail "CI token in config_${topology}.sh is expired against the CI cluster API (${CI_SERVER})" \
+          "log in at https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/, copy a fresh token, update CI_TOKEN in ${CONFIG_DIR}/config_${topology}.sh"
+      elif [[ "${HTTP_CODE}" == "200" ]]; then
+        check_pass "CI token in config_${topology}.sh accepted by CI cluster API (${CI_SERVER})"
+      else
+        check_warn "CI API token check: unexpected HTTP ${HTTP_CODE} from ${CI_SERVER}"
       fi
     fi
   fi


### PR DESCRIPTION
## Summary

- Add a new check in `doctor.sh` that validates `CI_TOKEN` against the CI cluster API server (`api.ci.l2s4.p1.openshiftapps.com`) whenever `CI_TOKEN` is non-empty — regardless of `RELEASE_REGISTRY`
- Uses `curl` against the OpenShift `users/~` endpoint (consistent with doctor's existing curl-based validation pattern)
- Renames the existing comment from "CI token live check" to "CI token registry check" for clarity

## Problem

`make doctor` validates the CI token only against the CI **registry** (`registry.ci.openshift.org/v2/`), and only when the release image is hosted there. For GA releases on `quay.io`, the registry check is correctly skipped — but dev-scripts still requires a valid CI token for `oc login` to the CI **cluster API** to generate pull secrets.

This creates a gap: doctor reports all clear, but deployment fails minutes later in `validation.sh` when `oc login` rejects an expired token.

## Test plan

- [x] With a valid CI token: `make doctor` shows `[PASS] CI token ... accepted by CI cluster API`
- [x] With an expired CI token: `make doctor` shows `[FAIL] CI token ... is expired against the CI cluster API` with console login URL as fix hint
- [x] With no CI token: the check does not run
- [x] With quay.io release image: the new API check runs (unlike the registry check, which is correctly skipped)
- [x] `make shellcheck` passes with no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect expired or invalid CI tokens during cluster health checks.
  * Health checks now report clear pass, warning, or failure results based on the CI API response.
  * Updated the CI token registry check label for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->